### PR TITLE
Minor fixes to agent installation

### DIFF
--- a/aws_secretsmanager_agent/configuration/awssmastartup.service
+++ b/aws_secretsmanager_agent/configuration/awssmastartup.service
@@ -13,7 +13,7 @@ Environment="AWS_TOKEN=file:///var/run/awssmatoken"
 Type=exec
 Restart=always
 TimeoutSec=1min
-ExecStart=/opt/aws/secretsmanageragent/bin/aws-secrets-manager-agent
+ExecStart=/opt/aws/secretsmanageragent/bin/aws_secretsmanager_agent
 
 [Install]
 WantedBy=multi-user.target

--- a/aws_secretsmanager_agent/configuration/install
+++ b/aws_secretsmanager_agent/configuration/install
@@ -3,7 +3,7 @@
 PATH=/bin:/usr/bin:/sbin:/usr/sbin # Use a safe path
 
 AGENTDIR=/opt/aws/secretsmanageragent
-AGENTBIN=aws-secrets-manager-agent
+AGENTBIN=aws_secretsmanager_agent
 TOKENGROUP=awssmatokenreader
 AGENTUSER=awssmauser
 TOKENSCRIPT=awssmaseedtoken
@@ -27,11 +27,12 @@ if [ ! -r ${AGENTBIN} ]; then
 fi
 
 groupadd -f ${TOKENGROUP}
-useradd -r -m -g ${TOKENGROUP} -d ${AGENTDIR} ${AGENTUSER}
+useradd -r -m -g ${TOKENGROUP} -d ${AGENTDIR} ${AGENTUSER} || true
 chmod 755 ${AGENTDIR}
 
 install -D -T -m 755 ${AGENTBIN} ${AGENTDIR}/bin/${AGENTBIN}
 install -D -T -m 755 ${TOKENSCRIPT} ${AGENTDIR}/bin/${TOKENSCRIPT}
+chown -R ${AGENTUSER} ${AGENTDIR}
 install -T -m 755 ${TOKENSCRIPT}.service ${SYSTEMDFILES}/${TOKENSCRIPT}.service 
 install -T -m 755 ${AGENTSCRIPT}.service ${SYSTEMDFILES}/${AGENTSCRIPT}.service
 


### PR DESCRIPTION


*Issue #, if available:*
N/A
*Description of changes:*
* Updated both the install script and the systemd service to use the executable name that is built (aws_secretsmanager_agent) instead of the previous aws-secrets-manager-agent.
* Due to install script running as root, files in bin directory are not owned by the AGENTUSER.  This is necessary for systemd run processes. Added additional chown to recursively set the owner to AGENTUSER within AGENTDIR.
* Added minor change to not fail if the AGENTUSER already exists.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
