### PR TITLE
Add AWS_CONTAINER_AUTHORIZATION_TOKEN as default value for SSRF_ENV_VARIABLES

### DIFF
--- a/aws_secretsmanager_agent/src/config.rs
+++ b/aws_secretsmanager_agent/src/config.rs
@@ -16,7 +16,11 @@ const DEFAULT_HTTP_PORT: &str = "2773";
 const DEFAULT_TTL_SECONDS: &str = "300";
 const DEFAULT_CACHE_SIZE: &str = "1000";
 const DEFAULT_SSRF_HEADERS: [&str; 2] = ["X-Aws-Parameters-Secrets-Token", "X-Vault-Token"];
-const DEFAULT_SSRF_ENV_VARIABLES: [&str; 2] = ["AWS_TOKEN", "AWS_SESSION_TOKEN"];
+const DEFAULT_SSRF_ENV_VARIABLES: [&str; 3] = [
+    "AWS_TOKEN",
+    "AWS_SESSION_TOKEN",
+    "AWS_CONTAINER_AUTHORIZATION_TOKEN",
+];
 const DEFAULT_PATH_PREFIX: &str = "/v1/";
 
 const DEFAULT_REGION: Option<String> = None;
@@ -194,7 +198,7 @@ impl Config {
     ///
     /// # Returns
     ///
-    /// * `ssrf_env_variables` - The name of the env variable containing the SSRF token value. Defaults to ["AWS_TOKEN", "AWS_SESSION_TOKEN"].
+    /// * `ssrf_env_variables` - The name of the env variable containing the SSRF token value. Defaults to ["AWS_TOKEN", "AWS_SESSION_TOKEN", "AWS_CONTAINER_AUTHORIZATION_TOKEN"].
     pub fn ssrf_env_variables(&self) -> Vec<String> {
         self.ssrf_env_variables.clone()
     }

--- a/aws_secretsmanager_agent/src/main.rs
+++ b/aws_secretsmanager_agent/src/main.rs
@@ -504,7 +504,7 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     #[should_panic(
-        expected = "Could not read SSRF token variable(s) [\"AWS_TOKEN\", \"AWS_SESSION_TOKEN\"]: Permission denied (os error 13) !!!"
+        expected = "Could not read SSRF token variable(s) [\"AWS_TOKEN\", \"AWS_SESSION_TOKEN\", \"AWS_CONTAINER_AUTHORIZATION_TOKEN\"]: Permission denied (os error 13) !!!"
     )]
     async fn bad_token_file() {
         // Generate a temp file with the default token and take away read permissions.


### PR DESCRIPTION
*Description of changes:*
This change adds AWS_CONTAINER_AUTHORIZATION_TOKEN as a default value for SSRF_ENV_VARIABLES config in addition to the already existing values AWS_TOKEN and AWS_SESSION_TOKEN.

The AWS_CONTAINER_AUTHORIZATION_TOKEN env variable contains the authorization token in ECS, EKS and even in Java Lambda's when SnapStart is enabled. Adding this env variable as another default value to SSRF_ENV_VARIABLES allows the Secrets Manager Agent to be used in the above containerized environments without developers having to manually add it. 

Refer : 
* https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html
* https://docs.aws.amazon.com/lambda/latest/dg/snapstart-activate.html

*Verification* 
* `cargo build` succeeds and all unit tests pass. 
* Manually tested by creating an Java Lambda Extension with SnapStart enabled, using the [example provided](https://github.com/aws/aws-secretsmanager-agent/tree/main/aws_secretsmanager_agent/examples/example-lambda-extension), and verified that the Agent is able to retrieve secrets. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
