### PR TITLE
Fix install instructions for EC2 and other typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target/
 **/*.rs.bk
 *.pdb
 logs/
+aws_secretsmanager_agent/configuration/aws_secretsmanager_agent
 
 #######
 

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/aws-secretsmanager-agent.iml
+++ b/.idea/aws-secretsmanager-agent.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ComposerSettings">
+    <execution />
+  </component>
+  <component name="JsBuildToolPackageJson" sorting="DEFINITION_ORDER" />
+  <component name="MarkdownSettingsMigration">
+    <option name="stateVersion" value="1" />
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+  <component name="accountSettings">
+    <option name="activeRegion" value="us-west-2" />
+    <option name="recentlyUsedRegions">
+      <list>
+        <option value="us-west-2" />
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/aws-secretsmanager-agent.iml" filepath="$PROJECT_DIR$/.idea/aws-secretsmanager-agent.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -139,11 +139,21 @@ Based on the type of compute, you have several options for installing the Secret
 
 **To install the Secrets Manager Agent**
 
-1. Use the `install` script provided in the repository\. 
+1. Copy the binary from the `target/` directory to the `aws_secretsmanager_agent/configuration/` directory:
+
+2. ```sh
+    cp target/release/aws_secretsmanager_agent aws_secretsmanager_agent/configuration/.
+    ```
+
+2. Use the `install` script provided in the repository:
+
+    ```sh
+    cd aws_secretsmanager_agent/configuration/ && ./install
+    ```
 
    The script generates a random SSRF token on startup and stores it in the file `/var/run/awssmatoken`\. The token is readable by the `awssmatokenreader` group that the install script creates\. 
 
-1. To allow your application to read the token file, you need to add the user account that your application runs under to the `awssmatokenreader` group\. For example, you can grant permissions for your application to read the token file with the following usermod command, where *<APP\_USER>* is the user ID under which your application runs\.
+3. To allow your application to read the token file, you need to add the user account that your application runs under to the `awssmatokenreader` group\. For example, you can grant permissions for your application to read the token file with the following usermod command, where *<APP\_USER>* is the user ID under which your application runs\.
 
    ```sh
    sudo usermod -aG awssmatokenreader <APP_USER>

--- a/README.md
+++ b/README.md
@@ -141,17 +141,17 @@ Based on the type of compute, you have several options for installing the Secret
 
 1. Copy the binary from the `target/` directory to the `aws_secretsmanager_agent/configuration/` directory:
 
-2. ```sh
+    ```sh
     cp target/release/aws_secretsmanager_agent aws_secretsmanager_agent/configuration/.
     ```
-
 2. Use the `install` script provided in the repository:
 
     ```sh
     cd aws_secretsmanager_agent/configuration/ && ./install
     ```
 
-   The script generates a random SSRF token on startup and stores it in the file `/var/run/awssmatoken`\. The token is readable by the `awssmatokenreader` group that the install script creates\. 
+   The script generates a random SSRF token on startup and stores it in the file `/var/run/awssmatoken`\. The token is readable by the `awssmatokenreader` group that the install script creates.
+
 
 3. To allow your application to read the token file, you need to add the user account that your application runs under to the `awssmatokenreader` group\. For example, you can grant permissions for your application to read the token file with the following usermod command, where *<APP\_USER>* is the user ID under which your application runs\.
 
@@ -295,7 +295,7 @@ The following curl example shows how to get a secret from the Secrets Manager Ag
 ```sh
 curl -v -H \
     "X-Aws-Parameters-Secrets-Token: $(</var/run/awssmatoken)" \
-    'http://localhost:2773/secretsmanager/get?secretId=<YOUR_SECRET_ID>}'; \
+    'http://localhost:2773/secretsmanager/get?secretId=<YOUR_SECRET_ID>'; \
     echo
 ```
 
@@ -311,7 +311,7 @@ import json
 # Function that fetches the secret from Secrets Manager Agent for the provided secret id. 
 def get_secret():
     # Construct the URL for the GET request
-    url = f"http://localhost:2773/secretsmanager/get?secretId=<YOUR_SECRET_ID>}"
+    url = f"http://localhost:2773/secretsmanager/get?secretId=<YOUR_SECRET_ID>"
 
     # Get the SSRF token from the token file
     with open('/var/run/awssmatoken') as fp:


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-secretsmanager-agent/issues/31


*Description of changes:*

Update README with improved instructions for EC2 installation and other typos

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
