### PR TITLE
Serve cache on transient errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -125,7 +125,7 @@ dependencies = [
  "fastrand",
  "hex",
  "http 0.2.12",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "ring",
  "time",
  "tokio",
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-secretsmanager"
-version = "1.38.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74011f98573dd2c499092ece401b93dbdd35de342c404a3cd7de34c282f877e8"
+checksum = "66a0cc1d41792d2d383746c154f48521715c50f5d59e9cdf36ef763de3c2345f"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.34.0"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcfae7bf8b8f14cade7579ffa8956fcee91dc23633671096b4b5de7d16f682a"
+checksum = "6acca681c53374bf1d9af0e317a41d12a44902ca0f2d1e10e5cb5bb98ed74f35"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -216,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.35.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b30def8f02ba81276d5dbc22e7bf3bed20d62d1b175eef82680d6bdc7a6f4c"
+checksum = "b79c6bdfe612503a526059c05c9ccccbf6bd9530b003673cb863e547fd7c0c9a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -238,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.34.0"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0804f840ad31537d5d1a4ec48d59de5e674ad05f1db7d3def2c9acadaf1f7e60"
+checksum = "32e6ecdb2bd756f3b2383e6f0588dc10a4e65f5d551e70a56e0bfe0c884673ce"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-protocol-test"
-version = "0.60.7"
+version = "0.60.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31e8279cb24640c7349f2bda6ca818d5fcc85129386bd73c1d0999430d6ddf2"
+checksum = "020468b04f916b36e0a791c4ebf80777ad2c25d8b9ebb8db14939e98a37abec0"
 dependencies = [
  "assert-json-diff",
  "aws-smithy-runtime-api",
@@ -360,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df4217d39fe940066174e6238310167bf466bfbebf3be0661e53cacccde6313"
+checksum = "ce87155eba55e11768b8c1afa607f3e864ae82f03caf63258b37455b0ad02537"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -374,9 +374,9 @@ dependencies = [
  "h2",
  "http 0.2.12",
  "http-body 0.4.6",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "httparse",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "hyper-rustls",
  "indexmap 2.2.6",
  "once_cell",
@@ -420,7 +420,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.1.0",
  "http-body 0.4.6",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "http-body-util",
  "itoa",
  "num-integer",
@@ -471,7 +471,7 @@ dependencies = [
  "config",
  "http 0.2.12",
  "http-body-util",
- "hyper 1.4.0",
+ "hyper 1.4.1",
  "hyper-util",
  "log",
  "log4rs",
@@ -491,6 +491,7 @@ dependencies = [
  "aws-sdk-secretsmanager",
  "aws-smithy-mocks-experimental",
  "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
  "aws-smithy-types",
  "http 0.2.12",
  "linked-hash-map",
@@ -565,9 +566,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "bytes-utils"
@@ -581,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.106"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066fce287b1d4eafef758e89e09d724a24808a9196fe9756b8ca90e86d0719a2"
+checksum = "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
 
 [[package]]
 name = "cfg-if"
@@ -601,7 +602,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -705,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -715,27 +716,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622687fe0bac72a04e5599029151f5796111b90f1baaa9b544d807a5e31cd120"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.70",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1018,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http 1.1.0",
@@ -1035,7 +1036,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1059,9 +1060,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.29"
+version = "0.14.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
+checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1083,15 +1084,15 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4fe55fb7a772d59a5ff1dfbff4fe0258d19b89fec4b233e75d35d5d2316badc"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -1109,7 +1110,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "log",
  "rustls",
  "rustls-native-certs",
@@ -1126,8 +1127,8 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
- "hyper 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.4.1",
  "pin-project-lite",
  "tokio",
 ]
@@ -1201,7 +1202,7 @@ checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1334,13 +1335,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
 dependencies = [
+ "hermit-abi",
  "libc",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1388,20 +1390,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "object"
-version = "0.36.1"
+version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
+checksum = "3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e"
 dependencies = [
  "memchr",
 ]
@@ -1469,7 +1461,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1515,7 +1507,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1647,9 +1639,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
  "bitflags",
 ]
@@ -1716,7 +1708,7 @@ dependencies = [
  "libc",
  "spin",
  "untrusted",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1820,7 +1812,7 @@ version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1841,9 +1833,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1854,9 +1846,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1895,35 +1887,36 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
 dependencies = [
  "indexmap 2.2.6",
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_with"
-version = "3.8.3"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e73139bc5ec2d45e6c5fd85be5a46949c1c39a4c18e56915f5eb4c12f975e377"
+checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -1939,14 +1932,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.8.3"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b80d3d6b56b64335c0180e5ffde23b3c5e08c14c585b51a15bd0e95393f46703"
+checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2013,7 +2006,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2047,9 +2040,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.70"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0209b68b3613b093e0ec905354eccaedcfe83b8cb37cbdeae64026c3064c16"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2067,29 +2060,29 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "thread-id"
-version = "4.2.1"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0ec81c46e9eb50deaa257be2f148adf052d1fb7701cfd55ccfab2525280b70b"
+checksum = "cfe8f25bbdd100db7e1d34acf7fd2dc59c4bf8f7483f505eaa7d4f12f76cc0ea"
 dependencies = [
  "libc",
  "winapi",
@@ -2162,31 +2155,30 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.0"
+version = "1.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2238,9 +2230,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.14"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
+checksum = "81967dd0dd2c1ab0bc3468bd7caecc32b8a4aa47d0c8c695d8c2b2108168d62c"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2250,18 +2242,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+checksum = "f8fb9f64314842840f1d940ac544da178732128f1c78c21772e876579e0da1db"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.15"
+version = "0.22.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59a3a72298453f564e2b111fa896f8d07fabb36f51f06d7e875fc5e0b5a3ef1"
+checksum = "8d9f8729f5aea9562aac1cc0441f5d6de3cff1ee0c5d67293eeca5eb36ee7c16"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
@@ -2295,7 +2287,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2444,9 +2436,9 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "uuid"
-version = "1.9.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 
 [[package]]
 name = "valuable"
@@ -2456,9 +2448,9 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vsimd"
@@ -2502,7 +2494,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.72",
  "wasm-bindgen-shared",
 ]
 
@@ -2524,7 +2516,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.72",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2557,7 +2549,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2572,16 +2564,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2590,22 +2573,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2614,21 +2582,15 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2638,21 +2600,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2668,21 +2618,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2692,21 +2630,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2716,9 +2642,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.13"
+version = "0.6.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
+checksum = "b480ae9340fc261e6be3e95a1ba86d54ae3f9171132a73ce8d4bbaf68339507c"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.72",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -180,10 +180,14 @@ You can run the Secrets Manager Agent as a sidecar container alongside your appl
 1. Create a Dockerfile for your client application\.
 
 1. Create a Docker Compose file to run both containers, being sure that they use the same network interface\. This is necessary because the Secrets Manager Agent does not accept requests from outside the localhost interface\. The following example shows a Docker Compose file where the `network_mode` key attaches the `secrets-manager-agent` container to the network namespace of the `client-application` container, which allows them to share the same network interface\.
-**Important**  
-You must load AWS credentials and the SSRF token for the application to be able to use the Secrets Manager Agent\. See the following:  
-[Manage access](https://docs.aws.amazon.com/eks/latest/userguide/cluster-auth.html) in the *Amazon Elastic Kubernetes Service User Guide*
-[Amazon ECS task IAM role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html) in the *Amazon Elastic Container Service Developer Guide*
+
+    **Important**  
+
+    You must load AWS credentials and the SSRF token for the application to be able to use the Secrets Manager Agent\. For EKS and ECS, see the following:  
+
+    [Manage access](https://docs.aws.amazon.com/eks/latest/userguide/cluster-auth.html) in the *Amazon Elastic Kubernetes Service User Guide*
+
+    [Amazon ECS task IAM role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html) in the *Amazon Elastic Container Service Developer Guide*
 
    ```yaml
    version: '3'
@@ -225,7 +229,7 @@ The following instructions show how to get a secret named *MyTest* by using the 
 
 **To create a Lambda extension that packages the Secrets Manager Agent**
 
-1. Create a Python Lambda function that queries `http://localhost:2773/secretsmanager/get?secretId=MyTest` to get the secret\. Be sure to implement retry logic in your application code to accommodate delays in initialization and registration of the Lambda extension\.
+1. Create a Python Lambda function that reads the SSRF token from environment variable `AWS_TOKEN`, and queries `http://localhost:2773/secretsmanager/get?secretId=MyTest` to get the secret. Be sure to specify environment variable `AWS_TOKEN` for your lambda, and additionally, implement retry logic in your application code to accommodate delays in initialization and registration of the Lambda extension\.
 
 1. From the root of the Secrets Manager Agent code package, run the following commands to test the Lambda extension\.
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,9 @@ Based on the type of compute, you have several options for installing the Secret
 
 **To install the Secrets Manager Agent**
 
-1. Use the `install` script provided in the repository\. 
+1. `cp target/release/aws-secrets-manager-agent aws_secretsmanager_agent/configuration/aws-secrets-manager-agent`
+1. `cd aws_secretsmanager_agent/configuration/aws-secrets-manager-agent`
+1. Run the `install` script provided in the repository\. 
 
    The script generates a random SSRF token on startup and stores it in the file `/var/run/awssmatoken`\. The token is readable by the `awssmatokenreader` group that the install script creates\. 
 
@@ -285,7 +287,7 @@ The following curl example shows how to get a secret from the Secrets Manager Ag
 ```sh
 curl -v -H \
     "X-Aws-Parameters-Secrets-Token: $(</var/run/awssmatoken)" \
-    'http://localhost:2773/secretsmanager/get?secretId=<YOUR_SECRET_ID>}'; \
+    'http://localhost:2773/secretsmanager/get?secretId=<YOUR_SECRET_ID>'; \
     echo
 ```
 
@@ -301,7 +303,7 @@ import json
 # Function that fetches the secret from Secrets Manager Agent for the provided secret id. 
 def get_secret():
     # Construct the URL for the GET request
-    url = f"http://localhost:2773/secretsmanager/get?secretId=<YOUR_SECRET_ID>}"
+    url = f"http://localhost:2773/secretsmanager/get?secretId=<YOUR_SECRET_ID>"
 
     # Get the SSRF token from the token file
     with open('/var/run/awssmatoken') as fp:

--- a/README.md
+++ b/README.md
@@ -181,13 +181,12 @@ You can run the Secrets Manager Agent as a sidecar container alongside your appl
 
 1. Create a Docker Compose file to run both containers, being sure that they use the same network interface\. This is necessary because the Secrets Manager Agent does not accept requests from outside the localhost interface\. The following example shows a Docker Compose file where the `network_mode` key attaches the `secrets-manager-agent` container to the network namespace of the `client-application` container, which allows them to share the same network interface\.
 
-    **Important**  
+    **Important**
 
     You must load AWS credentials and the SSRF token for the application to be able to use the Secrets Manager Agent\. For EKS and ECS, see the following:  
+    * [Manage access](https://docs.aws.amazon.com/eks/latest/userguide/cluster-auth.html) in the *Amazon Elastic Kubernetes Service User Guide*
+    * [Amazon ECS task IAM role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html) in the *Amazon Elastic Container Service Developer Guide*
 
-    [Manage access](https://docs.aws.amazon.com/eks/latest/userguide/cluster-auth.html) in the *Amazon Elastic Kubernetes Service User Guide*
-
-    [Amazon ECS task IAM role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html) in the *Amazon Elastic Container Service Developer Guide*
 
    ```yaml
    version: '3'

--- a/README.md
+++ b/README.md
@@ -139,8 +139,7 @@ Based on the type of compute, you have several options for installing the Secret
 
 **To install the Secrets Manager Agent**
 
-1. `cp target/release/aws-secrets-manager-agent aws_secretsmanager_agent/configuration/aws-secrets-manager-agent`
-1. `cd aws_secretsmanager_agent/configuration/aws-secrets-manager-agent`
+1. `cd aws_secretsmanager_agent/configuration`
 1. Run the `install` script provided in the repository\. 
 
    The script generates a random SSRF token on startup and stores it in the file `/var/run/awssmatoken`\. The token is readable by the `awssmatokenreader` group that the install script creates\. 

--- a/aws_secretsmanager_agent/configuration/install
+++ b/aws_secretsmanager_agent/configuration/install
@@ -2,7 +2,8 @@
 
 PATH=/bin:/usr/bin:/sbin:/usr/sbin # Use a safe path
 
-AGENTDIR=/opt/aws/secretsmanageragent
+AGENTTARGETDIR=/opt/aws/secretsmanageragent
+AGENTSOURCEDIR=../../target/release
 AGENTBIN=aws_secretsmanager_agent
 TOKENGROUP=awssmatokenreader
 AGENTUSER=awssmauser
@@ -21,18 +22,18 @@ if [ ! -r ${TOKENSCRIPT} ]; then
     exit 1
 fi
 
-if [ ! -r ${AGENTBIN} ]; then
+if [ ! -r ${AGENTSOURCEDIR}/${AGENTBIN} ]; then
     echo "Can not read ${AGENTBIN}" >&2
     exit 1
 fi
 
 groupadd -f ${TOKENGROUP}
-useradd -r -m -g ${TOKENGROUP} -d ${AGENTDIR} ${AGENTUSER} || true
-chmod 755 ${AGENTDIR}
+useradd -r -m -g ${TOKENGROUP} -d ${AGENTTARGETDIR} ${AGENTUSER} || true
+chmod 755 ${AGENTTARGETDIR}
 
-install -D -T -m 755 ${AGENTBIN} ${AGENTDIR}/bin/${AGENTBIN}
-install -D -T -m 755 ${TOKENSCRIPT} ${AGENTDIR}/bin/${TOKENSCRIPT}
-chown -R ${AGENTUSER} ${AGENTDIR}
+install -D -T -m 755 ${AGENTSOURCEDIR}/${AGENTBIN} ${AGENTTARGETDIR}/bin/${AGENTBIN}
+install -D -T -m 755 ${TOKENSCRIPT} ${AGENTTARGETDIR}/bin/${TOKENSCRIPT}
+chown -R ${AGENTUSER} ${AGENTTARGETDIR}
 install -T -m 755 ${TOKENSCRIPT}.service ${SYSTEMDFILES}/${TOKENSCRIPT}.service 
 install -T -m 755 ${AGENTSCRIPT}.service ${SYSTEMDFILES}/${AGENTSCRIPT}.service
 

--- a/aws_secretsmanager_agent/src/cache_manager.rs
+++ b/aws_secretsmanager_agent/src/cache_manager.rs
@@ -33,7 +33,7 @@ impl CacheManager {
             asm_client(cfg).await?,
             cfg.cache_size(),
             cfg.ttl(),
-            cfg.static_stability(),
+            cfg.ignore_transient_errors(),
         )?))
     }
 

--- a/aws_secretsmanager_agent/src/cache_manager.rs
+++ b/aws_secretsmanager_agent/src/cache_manager.rs
@@ -33,6 +33,7 @@ impl CacheManager {
             asm_client(cfg).await?,
             cfg.cache_size(),
             cfg.ttl(),
+            cfg.static_stability(),
         )?))
     }
 

--- a/aws_secretsmanager_agent/src/config.rs
+++ b/aws_secretsmanager_agent/src/config.rs
@@ -22,7 +22,7 @@ const DEFAULT_SSRF_ENV_VARIABLES: [&str; 3] = [
     "AWS_CONTAINER_AUTHORIZATION_TOKEN",
 ];
 const DEFAULT_PATH_PREFIX: &str = "/v1/";
-const DEFAULT_STATIC_STABILITY: bool = true;
+const DEFAULT_IGNORE_TRANSIENT_ERRORS: bool = true;
 
 const DEFAULT_REGION: Option<String> = None;
 
@@ -40,7 +40,7 @@ struct ConfigFile {
     path_prefix: String,
     max_conn: String,
     region: Option<String>,
-    static_stability: bool,
+    ignore_transient_errors: bool,
 }
 
 /// The log levels supported by the daemon.
@@ -101,7 +101,7 @@ pub struct Config {
     region: Option<String>,
 
     /// Whether the agent should serve cached data on transient refresh errors
-    static_stability: bool,
+    ignore_transient_errors: bool,
 }
 
 /// The default configuration options.
@@ -144,7 +144,7 @@ impl Config {
             .set_default("path_prefix", DEFAULT_PATH_PREFIX)?
             .set_default("max_conn", DEFAULT_MAX_CONNECTIONS)?
             .set_default("region", DEFAULT_REGION)?
-            .set_default("static_stability", DEFAULT_STATIC_STABILITY)?;
+            .set_default("ignore_transient_errors", DEFAULT_IGNORE_TRANSIENT_ERRORS)?;
 
         // Merge the config overrides onto the default configurations, if provided.
         config = match file_path {
@@ -242,9 +242,9 @@ impl Config {
     ///
     /// # Returns
     ///
-    /// * `static_stability` - Whether the client should serve cached data on transient refresh errors. Defaults to "true"
-    pub fn static_stability(&self) -> bool {
-        self.static_stability
+    /// * `ignore_transient_errors` - Whether the client should serve cached data on transient refresh errors. Defaults to "true"
+    pub fn ignore_transient_errors(&self) -> bool {
+        self.ignore_transient_errors
     }
 
     /// Private helper that fills in the Config instance from the specified
@@ -294,7 +294,7 @@ impl Config {
                 None,
             )?,
             region: config_file.region,
-            static_stability: config_file.static_stability,
+            ignore_transient_errors: config_file.ignore_transient_errors,
         };
 
         // Additional validations.
@@ -365,7 +365,7 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
-    /// Test helper function that returns the a ConfigFile with default values.
+    /// Test helper function that returns a ConfigFile with default values.
     fn get_default_config_file() -> ConfigFile {
         ConfigFile {
             log_level: String::from(DEFAULT_LOG_LEVEL),
@@ -377,7 +377,7 @@ mod tests {
             path_prefix: String::from(DEFAULT_PATH_PREFIX),
             max_conn: String::from(DEFAULT_MAX_CONNECTIONS),
             region: None,
-            static_stability: DEFAULT_STATIC_STABILITY,
+            ignore_transient_errors: DEFAULT_IGNORE_TRANSIENT_ERRORS,
         }
     }
 
@@ -403,7 +403,7 @@ mod tests {
         assert_eq!(config.clone().path_prefix(), DEFAULT_PATH_PREFIX);
         assert_eq!(config.clone().max_conn(), 800);
         assert_eq!(config.clone().region(), None);
-        assert_eq!(config.static_stability(), true);
+        assert_eq!(config.ignore_transient_errors(), true);
     }
 
     /// Tests the config overrides are applied correctly from the provided config file.
@@ -428,7 +428,7 @@ mod tests {
         assert_eq!(config.clone().path_prefix(), "/other");
         assert_eq!(config.clone().max_conn(), 10);
         assert_eq!(config.clone().region(), Some(&"us-west-2".to_string()));
-        assert_eq!(config.static_stability(), true);
+        assert_eq!(config.ignore_transient_errors(), false);
     }
 
     /// Tests that an Err is returned when an invalid value is provided in one of the configurations.

--- a/aws_secretsmanager_agent/src/config.rs
+++ b/aws_secretsmanager_agent/src/config.rs
@@ -22,6 +22,7 @@ const DEFAULT_SSRF_ENV_VARIABLES: [&str; 3] = [
     "AWS_CONTAINER_AUTHORIZATION_TOKEN",
 ];
 const DEFAULT_PATH_PREFIX: &str = "/v1/";
+const DEFAULT_STATIC_STABILITY: bool = true;
 
 const DEFAULT_REGION: Option<String> = None;
 
@@ -39,6 +40,7 @@ struct ConfigFile {
     path_prefix: String,
     max_conn: String,
     region: Option<String>,
+    static_stability: bool,
 }
 
 /// The log levels supported by the daemon.
@@ -97,6 +99,9 @@ pub struct Config {
 
     /// The AWS Region that will be used to send the Secrets Manager request to.
     region: Option<String>,
+
+    /// Whether the agent should serve cached data on transient refresh errors
+    static_stability: bool,
 }
 
 /// The default configuration options.
@@ -138,7 +143,8 @@ impl Config {
             )?
             .set_default("path_prefix", DEFAULT_PATH_PREFIX)?
             .set_default("max_conn", DEFAULT_MAX_CONNECTIONS)?
-            .set_default("region", DEFAULT_REGION)?;
+            .set_default("region", DEFAULT_REGION)?
+            .set_default("static_stability", DEFAULT_STATIC_STABILITY)?;
 
         // Merge the config overrides onto the default configurations, if provided.
         config = match file_path {
@@ -232,6 +238,15 @@ impl Config {
         self.region.as_ref()
     }
 
+    /// Whether the client should serve cached data on transient refresh errors
+    ///
+    /// # Returns
+    ///
+    /// * `static_stability` - Whether the client should serve cached data on transient refresh errors. Defaults to "true"
+    pub fn static_stability(&self) -> bool {
+        self.static_stability
+    }
+
     /// Private helper that fills in the Config instance from the specified
     /// config overrides (or defaults).
     ///
@@ -279,6 +294,7 @@ impl Config {
                 None,
             )?,
             region: config_file.region,
+            static_stability: config_file.static_stability,
         };
 
         // Additional validations.
@@ -361,6 +377,7 @@ mod tests {
             path_prefix: String::from(DEFAULT_PATH_PREFIX),
             max_conn: String::from(DEFAULT_MAX_CONNECTIONS),
             region: None,
+            static_stability: DEFAULT_STATIC_STABILITY,
         }
     }
 
@@ -386,6 +403,7 @@ mod tests {
         assert_eq!(config.clone().path_prefix(), DEFAULT_PATH_PREFIX);
         assert_eq!(config.clone().max_conn(), 800);
         assert_eq!(config.clone().region(), None);
+        assert_eq!(config.static_stability(), true);
     }
 
     /// Tests the config overrides are applied correctly from the provided config file.
@@ -410,6 +428,7 @@ mod tests {
         assert_eq!(config.clone().path_prefix(), "/other");
         assert_eq!(config.clone().max_conn(), 10);
         assert_eq!(config.clone().region(), Some(&"us-west-2".to_string()));
+        assert_eq!(config.static_stability(), true);
     }
 
     /// Tests that an Err is returned when an invalid value is provided in one of the configurations.

--- a/aws_secretsmanager_agent/src/main.rs
+++ b/aws_secretsmanager_agent/src/main.rs
@@ -79,10 +79,9 @@ fn forever() -> bool {
 ///
 /// # Arguments
 ///
-/// * `addr` - The socket address on which the daemon is listening.
+/// * `args` - The command line arguments.
 /// * `report` - A call back used to report startup and the listener port.
 /// * `end` - A call back used to signal shut down.
-///
 /// # Returns
 ///
 /// * `Ok(())` - Never retuned when started by the main entry point.

--- a/aws_secretsmanager_agent/src/utils.rs
+++ b/aws_secretsmanager_agent/src/utils.rs
@@ -1,10 +1,10 @@
 use crate::config::Config;
 use crate::constants::{APPNAME, MAX_REQ_TIME_SEC, VERSION};
-use aws_secretsmanager_caching::error::is_transient_error;
 use aws_sdk_secretsmanager::config::interceptors::BeforeTransmitInterceptorContextMut;
 use aws_sdk_secretsmanager::config::{ConfigBag, Intercept, RuntimeComponents};
 #[cfg(not(test))]
 use aws_sdk_secretsmanager::Client as SecretsManagerClient;
+use aws_secretsmanager_caching::error::is_transient_error;
 use std::env::VarError;
 use std::fs;
 use std::time::Duration;

--- a/aws_secretsmanager_agent/tests/resources/configs/config_file_valid.toml
+++ b/aws_secretsmanager_agent/tests/resources/configs/config_file_valid.toml
@@ -6,8 +6,8 @@ ssrf_env_variables = ["MY_TOKEN"]
 path_prefix = "/other"
 # checking that number with no quotes work.
 ttl_seconds = 300
-# checking that numbe with single quote works
+# checking that number with single quote works
 cache_size = '1000'
 max_conn = 10
 region = "us-west-2"
-static_stability = true
+ignore_transient_errors = false

--- a/aws_secretsmanager_agent/tests/resources/configs/config_file_valid.toml
+++ b/aws_secretsmanager_agent/tests/resources/configs/config_file_valid.toml
@@ -10,4 +10,4 @@ ttl_seconds = 300
 cache_size = '1000'
 max_conn = 10
 region = "us-west-2"
-
+static_stability = true

--- a/aws_secretsmanager_caching/Cargo.toml
+++ b/aws_secretsmanager_caching/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 
 [dependencies]
 aws-sdk-secretsmanager = "1"
+aws-smithy-runtime-api = "1"
 aws-smithy-types = "1"
 serde_json = "1"
 serde_with = "3"

--- a/aws_secretsmanager_caching/Cargo.toml
+++ b/aws_secretsmanager_caching/Cargo.toml
@@ -22,7 +22,7 @@ aws-config = "1"
 
 [dev-dependencies]
 aws-smithy-mocks-experimental = "0"
-aws-smithy-runtime = { version = "1", features = ["test-util"] }
+aws-smithy-runtime = { version = "1", features = ["test-util", "wire-mock"] }
 aws-sdk-secretsmanager = { version = "1", features = ["test-util"] }
 tokio = { version = "1", features = ["macros", "rt", "sync", "test-util"] }
 http = "0"

--- a/aws_secretsmanager_caching/README.md
+++ b/aws_secretsmanager_caching/README.md
@@ -72,6 +72,7 @@ let client = match SecretsManagerCachingClient::from_builder(
     asm_builder,
     NonZeroUsize::new(1000).unwrap(),
     Duration::from_secs(300),
+    false
 )
 .await
 {

--- a/aws_secretsmanager_caching/src/error.rs
+++ b/aws_secretsmanager_caching/src/error.rs
@@ -1,12 +1,22 @@
-use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretError;
 use aws_smithy_runtime_api::client::{orchestrator::HttpResponse, result::SdkError};
 
-pub(crate) fn is_transient_error(e: &SdkError<DescribeSecretError, HttpResponse>) -> bool {
+/// Helper function to determine transient errors. Transient errors include any timeout error,
+/// unparseable response error, dispatch error due to timeout or IO, and 5xx server-side error.
+///
+/// # Arguments
+/// * `e` - An SDK error
+///
+/// # Returns
+/// * true if transient error, false if not
+pub fn is_transient_error<S>(e: &SdkError<S, HttpResponse>) -> bool
+where
+    S: std::error::Error + 'static,
+{
     match e {
-        SdkError::TimeoutError(_)
-        | SdkError::ResponseError(_)
-        | SdkError::DispatchFailure(_)
-        | SdkError::ConstructionFailure(_) => true,
+        SdkError::TimeoutError(_) => true,
+        SdkError::ResponseError(_) => true,
+        SdkError::DispatchFailure(derr) if derr.is_timeout() || derr.is_io() => true,
+        SdkError::ServiceError(serr) if serr.raw().status().is_server_error() => true,
         _ => false,
     }
 }

--- a/aws_secretsmanager_caching/src/error.rs
+++ b/aws_secretsmanager_caching/src/error.rs
@@ -1,0 +1,12 @@
+use aws_sdk_secretsmanager::operation::describe_secret::DescribeSecretError;
+use aws_smithy_runtime_api::client::{orchestrator::HttpResponse, result::SdkError};
+
+pub(crate) fn is_transient_error(e: &SdkError<DescribeSecretError, HttpResponse>) -> bool {
+    match e {
+        SdkError::TimeoutError(_)
+        | SdkError::ResponseError(_)
+        | SdkError::DispatchFailure(_)
+        | SdkError::ConstructionFailure(_) => true,
+        _ => false,
+    }
+}

--- a/aws_secretsmanager_caching/src/lib.rs
+++ b/aws_secretsmanager_caching/src/lib.rs
@@ -61,6 +61,7 @@ impl SecretsManagerCachingClient {
     ///     asm_client,
     ///     NonZeroUsize::new(1000).unwrap(),
     ///     Duration::from_secs(300),
+    ///     false,
     /// );
     /// ```
     pub fn new(
@@ -100,7 +101,7 @@ impl SecretsManagerCachingClient {
             .interceptor(CachingLibraryInterceptor);
 
         let asm_client = SecretsManagerClient::from_conf(asm_builder.build());
-        Self::new(asm_client, max_size, ttl)
+        Self::new(asm_client, max_size, ttl, false)
     }
 
     /// Create a new caching client with in-memory store from an AWS SDK client builder
@@ -130,6 +131,7 @@ impl SecretsManagerCachingClient {
     /// asm_builder,
     /// NonZeroUsize::new(1000).unwrap(),
     /// Duration::from_secs(300),
+    /// false,
     /// )
     /// .await.unwrap();
     /// })
@@ -138,11 +140,12 @@ impl SecretsManagerCachingClient {
         asm_builder: aws_sdk_secretsmanager::config::Builder,
         max_size: NonZeroUsize,
         ttl: Duration,
+        ignore_transient_errors: bool,
     ) -> Result<Self, SecretStoreError> {
         let asm_client = SecretsManagerClient::from_conf(
             asm_builder.interceptor(CachingLibraryInterceptor).build(),
         );
-        Self::new(asm_client, max_size, ttl)
+        Self::new(asm_client, max_size, ttl, ignore_transient_errors)
     }
 
     /// Retrieves the value of the secret from the specified version.

--- a/aws_secretsmanager_caching/src/lib.rs
+++ b/aws_secretsmanager_caching/src/lib.rs
@@ -7,6 +7,8 @@
 
 //! AWS Secrets Manager Caching Library
 
+/// Error types
+mod error;
 /// Output of secret store
 pub mod output;
 /// Manages the lifecycle of cached secrets
@@ -15,6 +17,7 @@ mod utils;
 
 use aws_config::BehaviorVersion;
 use aws_sdk_secretsmanager::Client as SecretsManagerClient;
+use error::is_transient_error;
 use secret_store::SecretStoreError;
 
 use output::GetSecretValueOutputDef;
@@ -30,6 +33,7 @@ pub struct SecretsManagerCachingClient {
     asm_client: SecretsManagerClient,
     /// A store used to cache secrets.
     store: RwLock<Box<dyn SecretStore>>,
+    static_stability: bool,
 }
 
 impl SecretsManagerCachingClient {
@@ -40,6 +44,7 @@ impl SecretsManagerCachingClient {
     /// * `asm_client` - Initialized AWS SDK Secrets Manager client instance
     /// * `max_size` - Maximum size of the store.
     /// * `ttl` - Time-to-live of the secrets in the store.
+    /// * `static_stability` - Whether the client should serve cached data on transient refresh errors
     /// ```rust
     /// use aws_sdk_secretsmanager::Client as SecretsManagerClient;
     /// use aws_sdk_secretsmanager::{config::Region, Config};
@@ -62,10 +67,12 @@ impl SecretsManagerCachingClient {
         asm_client: SecretsManagerClient,
         max_size: NonZeroUsize,
         ttl: Duration,
+        static_stability: bool,
     ) -> Result<Self, SecretStoreError> {
         Ok(Self {
             asm_client,
             store: RwLock::new(Box::new(MemoryStore::new(max_size, ttl))),
+            static_stability,
         })
     }
 
@@ -163,9 +170,18 @@ impl SecretsManagerCachingClient {
             }
             Err(SecretStoreError::CacheExpired(cached_value)) => {
                 drop(read_lock);
-                Ok(self
-                    .refresh_secret_value(secret_id, version_id, version_stage, Some(cached_value))
-                    .await?)
+                match self
+                    .refresh_secret_value(
+                        secret_id,
+                        version_id,
+                        version_stage,
+                        Some(cached_value.clone()),
+                    )
+                    .await
+                {
+                    Ok(r) => Ok(r),
+                    Err(e) => Err(e.into()),
+                }
             }
             Err(e) => Err(Box::new(e)),
         }
@@ -191,14 +207,14 @@ impl SecretsManagerCachingClient {
                 .is_current(version_id, version_stage, cached_value.clone())
                 .await?
             {
-                // Refresh the TTL by writing the same data back to the cache.
+                // Re-up the entry freshness (TTL, cache rank) by writing the same data back to the cache.
                 self.store.write().await.write_secret_value(
                     secret_id.to_owned(),
                     version_id.map(String::from),
                     version_stage.map(String::from),
                     *cached_value.clone(),
                 )?;
-
+                // Serve the cached value
                 return Ok(*cached_value);
             }
         }
@@ -239,12 +255,22 @@ impl SecretsManagerCachingClient {
         version_stage: Option<&str>,
         cached_value: Box<GetSecretValueOutputDef>,
     ) -> Result<bool, Box<dyn Error>> {
-        let describe = self
+        let describe = match self
             .asm_client
             .describe_secret()
             .secret_id(cached_value.arn.unwrap())
             .send()
-            .await?;
+            .await
+        {
+            Ok(r) => r,
+            Err(e) if self.static_stability => {
+                return match is_transient_error(&e) {
+                    true => Ok(true),
+                    false => Err(e.into()),
+                }
+            }
+            Err(e) => return Err(e.into()),
+        };
 
         let real_vids_to_stages = match describe.version_ids_to_stages() {
             Some(vids_to_stages) => vids_to_stages,
@@ -288,6 +314,7 @@ mod tests {
                 Some(ttl) => ttl,
                 None => Duration::from_secs(1000),
             },
+            false,
         )
         .expect("client should create")
     }

--- a/aws_secretsmanager_caching/src/output.rs
+++ b/aws_secretsmanager_caching/src/output.rs
@@ -7,9 +7,8 @@ use std::time::SystemTime;
 
 /// Exhaustive structure to store the secret value
 ///
-/// We tried to De/Serialize the remote types using <https://serde.rs/remote-derive.html> but couldn't as the remote types are non_exhaustive
-/// This is a Rust limitation; for logical explaination see <https://amzn-aws.slack.com/archives/C017S7L2430/p1688495903715449>
-/// We can remove this when aws sdk implements De/Serialize trait for the types.
+/// We tried to De/Serialize the remote types using <https://serde.rs/remote-derive.html> but couldn't as the remote types are non_exhaustive,
+/// which is a Rust limitation. We can remove this when aws sdk implements De/Serialize trait for the types.
 #[serde_as]
 #[derive(::std::clone::Clone, ::std::cmp::PartialEq, Debug, Serialize, Deserialize, Default)]
 #[serde(rename_all = "PascalCase")]

--- a/aws_secretsmanager_caching/src/secret_store/memory_store/cache.rs
+++ b/aws_secretsmanager_caching/src/secret_store/memory_store/cache.rs
@@ -16,7 +16,7 @@ impl<K: Hash + Eq, V> Default for Cache<K, V> {
 }
 
 impl<K: Hash + Eq, V> Cache<K, V> {
-    /// Returns a new LRUCache with default configuration.
+    /// Returns a new least recently updated cache with default configuration.
     pub fn new(max_size: NonZeroUsize) -> Self {
         Cache {
             entries: LinkedHashMap::new(),
@@ -31,7 +31,7 @@ impl<K: Hash + Eq, V> Cache<K, V> {
 
     /// Inserts a key into the cache.
     ///  If the key already exists, it overwrites it
-    ///  If the insert results in too many keys in the cache, the LRU item is removed.
+    ///  If the insert results in too many keys in the cache, the oldest updated entry is removed.
     pub fn insert(&mut self, key: K, val: V) {
         self.entries.insert(key, val);
         if self.len() > self.max_size.get() {

--- a/aws_secretsmanager_caching/src/secret_store/memory_store/mod.rs
+++ b/aws_secretsmanager_caching/src/secret_store/memory_store/mod.rs
@@ -21,14 +21,14 @@ struct Key {
 #[derive(Debug, Clone)]
 struct GSVValue {
     value: GetSecretValueOutputDef,
-    last_retrieved_at: Instant,
+    last_updated_at: Instant,
 }
 
 impl GSVValue {
     fn new(value: GetSecretValueOutputDef) -> Self {
         Self {
             value,
-            last_retrieved_at: Instant::now(),
+            last_updated_at: Instant::now(),
         }
     }
 }
@@ -68,7 +68,7 @@ impl SecretStore for MemoryStore {
             version_id: version_id.map(String::from),
             version_stage: version_stage.map(String::from),
         }) {
-            Some(gsv) if gsv.last_retrieved_at.elapsed() > self.ttl => {
+            Some(gsv) if gsv.last_updated_at.elapsed() > self.ttl => {
                 Err(SecretStoreError::CacheExpired(Box::new(gsv.value.clone())))
             }
             Some(gsv) => Ok(gsv.clone().value),


### PR DESCRIPTION
STSGetCallerIdentity, DescribeSecret and GetSecretValue requests may fail because of common network errors like Sdkerror::Timeout and server-side errors like Sdkerror::ServiceError<Box, HttpResponse>. This cr adds a new configurable parameter ignore_transient_errors. With that enabled, the agent will return the cached secret when running into common transient errors like the above.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
