### PR TITLE
Fixed typo in README : aws-secrets-manager-agent to aws_secretsmanager_agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To build the Secrets Manager Agent binary natively, you need the standard develo
    cargo build --release
    ```
 
-   You will find the executable under `target/release/aws-secrets-manager-agent`\.
+   You will find the executable under `target/release/aws_secretsmanager_agent`\.
 
 ------
 #### [ Debian\-based systems ]
@@ -79,7 +79,7 @@ To build the Secrets Manager Agent binary natively, you need the standard develo
    cargo build --release
    ```
 
-   You will find the executable under `target/release/aws-secrets-manager-agent`\.
+   You will find the executable under `target/release/aws_secretsmanager_agent`\.
 
 ------
 #### [ Windows ]
@@ -103,7 +103,7 @@ rustup target add x86_64-pc-windows-gnu
 cargo build --release --target x86_64-pc-windows-gnu
 ```
 
-You will find the executable at `target/x86_64-pc-windows-gnu/release/aws-secrets-manager-agent.exe`\.
+You will find the executable at `target/x86_64-pc-windows-gnu/release/aws_secretsmanager_agent.exe`\.
 
 ------
 #### [ Cross compile with Rust cross ]
@@ -336,7 +336,7 @@ def get_secret():
 
 ## Configure the Secrets Manager Agent<a name="secrets-manager-agent-config"></a>
 
-To change the configuration of the Secrets Manager Agent, create a [TOML](https://toml.io/en/) config file, and then call `./aws-secrets-manager-agent --config config.toml`\.
+To change the configuration of the Secrets Manager Agent, create a [TOML](https://toml.io/en/) config file, and then call `./aws_secretsmanager_agent --config config.toml`\.
 
 The following list shows the options you can configure for the Secrets Manager Agent\.
 + **log\_level** – The level of detail reported in logs for the Secrets Manager Agent: DEBUG, INFO, WARN, ERROR, or NONE\. The default is INFO\.


### PR DESCRIPTION
*Description of changes:*
The binary file that's generated under `target` folder after `cargo build --release` is wrong mentioned as `aws-secrets-manager-agent` in the README file. I was able verify that it should actually be `aws_secretsmanager_agent`. 

*Verification*
```
➜  aws-secretsmanager-agent git:(main) ls target/release/
aws_secretsmanager_agent    build  examples     libaws_secretsmanager_caching.d
aws_secretsmanager_agent.d  deps   incremental  libaws_secretsmanager_caching.rlib


➜  aws-secretsmanager-agent git:(main) ls target/x86_64-unknown-linux-gnu/release/
aws_secretsmanager_agent    build  examples     libaws_secretsmanager_caching.d
aws_secretsmanager_agent.d  deps   incremental  libaws_secretsmanager_caching.rlib
```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
