### PR TITLE
Add Config Parameter to Disable STS Credential Validation

### DIFF
--- a/aws_secretsmanager_agent/src/config.rs
+++ b/aws_secretsmanager_agent/src/config.rs
@@ -612,6 +612,7 @@ mod tests {
         assert_eq!(config.clone().log_level(), LogLevel::Info);
         assert_eq!(config.clone().http_port(), 2773);
         assert_eq!(config.clone().ttl(), Duration::from_secs(300));
+        assert!(config.validate_credentials());
         assert_eq!(
             config.clone().cache_size(),
             NonZeroUsize::new(1000).unwrap()
@@ -638,17 +639,5 @@ mod tests {
             "tests/resources/configs/config_file_with_invalid_contents.toml",
         ))
         .unwrap();
-    }
-
-    /// Tests that validate_credentials defaults to true and can be overridden
-    #[test]
-    fn test_validate_credentials() {
-        // Test default value
-        let config = Config::default();
-        assert!(config.validate_credentials());
-
-        // Test override to false
-        let config = Config::new(Some("tests/resources/configs/config_file_valid.toml")).unwrap();
-        assert!(!config.validate_credentials());
     }
 }

--- a/aws_secretsmanager_agent/src/config.rs
+++ b/aws_secretsmanager_agent/src/config.rs
@@ -23,6 +23,7 @@ const DEFAULT_SSRF_ENV_VARIABLES: [&str; 3] = [
 ];
 const DEFAULT_PATH_PREFIX: &str = "/v1/";
 const DEFAULT_IGNORE_TRANSIENT_ERRORS: bool = true;
+const DEFAULT_VALIDATE_CREDENTIALS: bool = true;
 
 const DEFAULT_REGION: Option<String> = None;
 
@@ -41,6 +42,7 @@ struct ConfigFile {
     max_conn: String,
     region: Option<String>,
     ignore_transient_errors: bool,
+    validate_credentials: bool,
 }
 
 /// The log levels supported by the daemon.
@@ -102,6 +104,9 @@ pub struct Config {
 
     /// Whether the agent should serve cached data on transient refresh errors
     ignore_transient_errors: bool,
+
+    /// Whether to validate AWS credentials on startup using STS GetCallerIdentity
+    validate_credentials: bool,
 }
 
 /// The default configuration options.
@@ -144,7 +149,8 @@ impl Config {
             .set_default("path_prefix", DEFAULT_PATH_PREFIX)?
             .set_default("max_conn", DEFAULT_MAX_CONNECTIONS)?
             .set_default("region", DEFAULT_REGION)?
-            .set_default("ignore_transient_errors", DEFAULT_IGNORE_TRANSIENT_ERRORS)?;
+            .set_default("ignore_transient_errors", DEFAULT_IGNORE_TRANSIENT_ERRORS)?
+            .set_default("validate_credentials", DEFAULT_VALIDATE_CREDENTIALS)?;
 
         // Merge the config overrides onto the default configurations, if provided.
         config = match file_path {
@@ -247,6 +253,15 @@ impl Config {
         self.ignore_transient_errors
     }
 
+    /// Whether to validate AWS credentials on startup using STS GetCallerIdentity
+    ///
+    /// # Returns
+    ///
+    /// * `validate_credentials` - Whether to validate credentials on startup. Defaults to true.
+    pub fn validate_credentials(&self) -> bool {
+        self.validate_credentials
+    }
+
     /// Private helper that fills in the Config instance from the specified
     /// config overrides (or defaults).
     ///
@@ -295,6 +310,7 @@ impl Config {
             )?,
             region: config_file.region,
             ignore_transient_errors: config_file.ignore_transient_errors,
+            validate_credentials: config_file.validate_credentials,
         };
 
         // Additional validations.
@@ -378,6 +394,7 @@ mod tests {
             max_conn: String::from(DEFAULT_MAX_CONNECTIONS),
             region: None,
             ignore_transient_errors: DEFAULT_IGNORE_TRANSIENT_ERRORS,
+            validate_credentials: DEFAULT_VALIDATE_CREDENTIALS,
         }
     }
 
@@ -404,6 +421,7 @@ mod tests {
         assert_eq!(config.clone().max_conn(), 800);
         assert_eq!(config.clone().region(), None);
         assert!(config.ignore_transient_errors());
+        assert!(config.validate_credentials());
     }
 
     /// Tests the config overrides are applied correctly from the provided config file.
@@ -429,6 +447,7 @@ mod tests {
         assert_eq!(config.clone().max_conn(), 10);
         assert_eq!(config.clone().region(), Some(&"us-west-2".to_string()));
         assert!(!config.ignore_transient_errors());
+        assert!(!config.validate_credentials());
     }
 
     /// Tests that an Err is returned when an invalid value is provided in one of the configurations.
@@ -619,5 +638,17 @@ mod tests {
             "tests/resources/configs/config_file_with_invalid_contents.toml",
         ))
         .unwrap();
+    }
+
+    /// Tests that validate_credentials defaults to true and can be overridden
+    #[test]
+    fn test_validate_credentials() {
+        // Test default value
+        let config = Config::default();
+        assert!(config.validate_credentials());
+
+        // Test override to false
+        let config = Config::new(Some("tests/resources/configs/config_file_valid.toml")).unwrap();
+        assert!(!config.validate_credentials());
     }
 }

--- a/aws_secretsmanager_agent/src/utils.rs
+++ b/aws_secretsmanager_agent/src/utils.rs
@@ -128,20 +128,26 @@ pub async fn validate_and_create_asm_client(
     let default_config = &aws_config::load_defaults(BehaviorVersion::latest()).await;
     let mut asm_builder = aws_sdk_secretsmanager::config::Builder::from(default_config)
         .interceptor(AgentModifierInterceptor);
-    let mut sts_builder = aws_sdk_sts::config::Builder::from(default_config);
 
     if let Some(region) = config.region() {
         asm_builder.set_region(Some(Region::new(region.clone())));
-        sts_builder.set_region(Some(Region::new(region.clone())));
     }
 
-    // Validate the region and credentials first
-    let sts_client = aws_sdk_sts::Client::from_conf(sts_builder.build());
-    match sts_client.get_caller_identity().send().await {
-        Ok(_) => (),
-        Err(e) if config.ignore_transient_errors() && is_transient_error(&e) => (),
-        Err(e) => Err(e)?,
-    };
+    // Only perform STS validation if enabled
+    if config.validate_credentials() {
+        let mut sts_builder = aws_sdk_sts::config::Builder::from(default_config);
+        if let Some(region) = config.region() {
+            sts_builder.set_region(Some(Region::new(region.clone())));
+        }
+
+        // Validate the region and credentials first
+        let sts_client = aws_sdk_sts::Client::from_conf(sts_builder.build());
+        match sts_client.get_caller_identity().send().await {
+            Ok(_) => (),
+            Err(e) if config.ignore_transient_errors() && is_transient_error(&e) => (),
+            Err(e) => Err(e)?,
+        };
+    }
 
     Ok(aws_sdk_secretsmanager::Client::from_conf(
         asm_builder.build(),

--- a/aws_secretsmanager_agent/tests/resources/configs/config_file_valid.toml
+++ b/aws_secretsmanager_agent/tests/resources/configs/config_file_valid.toml
@@ -11,3 +11,4 @@ cache_size = '1000'
 max_conn = 10
 region = "us-west-2"
 ignore_transient_errors = false
+validate_credentials = false


### PR DESCRIPTION
*Issue #, if available:* #36

*Description of changes:*
This PR introduces a new configuration parameter, validate_credentials, that allows users to disable the STS GetCallerIdentity check performed during the startup of the AWS Secrets Manager agent. By default, the credential validation is enabled to ensure credentials are valid during initialization and to ensure backwards compatibility, but this parameter provides flexibility for environments where the validation may not be required.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
