### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ The following instructions show how to get a secret named *MyTest* by using the 
        --zip-file "fileb://secrets-manager-agent-extension.zip" | jq -r '.LayerVersionArn')
    ```
 
-2. The default configuration of the agent will automatically set the SSRF token to the value set in the pre-set `AWS_SESSION_TOKEN` or `AWS_CONTAINER_AUTHORIZATION_TOKEN` environment variables (the latter variable for Java-based Lambda functions with SnapStart enabled). Alternatively, you can define the `AWS_TOKEN` environment variable with an arbitrary value for your Lambda function instead as this variable takes precedence over the other two. If you choose to use the `AWS_TOKEN` environment variable, you must set that environment variable with a `lambda:UpdateFunctionConfiguration` call\.
+2. The default configuration of the agent will automatically set the SSRF token to the value set in the pre-set `AWS_SESSION_TOKEN` or `AWS_CONTAINER_AUTHORIZATION_TOKEN` environment variables (the latter variable for Lambda functions with SnapStart enabled). Alternatively, you can define the `AWS_TOKEN` environment variable with an arbitrary value for your Lambda function instead as this variable takes precedence over the other two. If you choose to use the `AWS_TOKEN` environment variable, you must set that environment variable with a `lambda:UpdateFunctionConfiguration` call\.
 
 
 3. Attach the layer version  to your Lambda function:


### PR DESCRIPTION
*Issue #, if available:*
#58 

*Description of changes:*
Fix typo.  Snapstart is no longer just for for java based lambdas: https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html#snapstart-runtimes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
