### PR TITLE
Provide a feature to prefer post quantum key exchange.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "aws_secretsmanager_agent"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "aws_secretsmanager_caching"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",
@@ -581,6 +581,7 @@ dependencies = [
  "aws-smithy-types",
  "http 0.2.12",
  "linked-hash-map",
+ "rustls 0.23.25",
  "serde",
  "serde_json",
  "serde_with",
@@ -2338,6 +2339,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki 0.103.0",

--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ To download the source code, see [https://github\.com/aws/aws\-secretsmanager\-a
   - [Step 3: Retrieve secrets with the Secrets Manager Agent](#step-3-retrieve-secrets-with-the-secrets-manager-agent)
       - [\[ curl \]](#-curl-)
       - [\[ Python \]](#-python-)
+  - [`refreshNow` parameter behavior](#refreshnow-parameter-behavior)
+  - [Using the refreshNow parameter](#using-the-refreshnow-parameter)
+    - [Example - Secrets Manager Agent GET request with refreshNow parameter](#example---secrets-manager-agent-get-request-with-refreshnow-parameter)
+      - [\[ curl \]](#-curl--1)
+      - [\[ Python \]](#-python--1)
   - [Configure the Secrets Manager Agent](#configure-the-secrets-manager-agent)
+  - [Optional features](#optional-features)
   - [Logging](#logging)
   - [Security considerations](#security-considerations)
 
@@ -450,6 +456,11 @@ The following list shows the options you can configure for the Secrets Manager A
 + **ssrf\_env\_variables** – A list of environment variable names the Secrets Manager Agent checks in sequential order for the SSRF token\. The environment variable can contain the token or a reference to the token file as in: `AWS_TOKEN=file:///var/run/awssmatoken`\. The default is "AWS\_TOKEN, AWS\_SESSION\_TOKEN, AWS\_CONTAINER\_AUTHORIZATION\_TOKEN\".
 + **path\_prefix** – The URI prefix used to determine if the request is a path based request\. The default is "/v1/"\.
 + **max\_conn** – The maximum number of connections from HTTP clients that the Secrets Manager Agent allows, in the range 1 to 1000\. The default is 800\.
+
+## Optional features<a name="secrets-manager-agent-features"></a>
+
+The Secrets Manager Agent can be built with optional features by passing the `--features` flag to `cargo build`. The available features are:
+* `prefer-post-quantum`: makes `X25519MLKEM768` the highest-priority key exchange algorithm. Otherwise, it is available but not highest-priority. `X25519MLKEM768` is a hybrid, post-quantum-secure key exchange algorithm.
 
 ## Logging<a name="secrets-manager-agent-log"></a>
 

--- a/aws_secretsmanager_agent/Cargo.toml
+++ b/aws_secretsmanager_agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws_secretsmanager_agent"
-version = "1.0.1"
+version = "1.1.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "The AWS Secrets Manager Agent is a local HTTP service that you can install and use in your compute environments to read secrets from Secrets Manager and cache them in memory."
@@ -28,7 +28,7 @@ aws-sdk-sts = "1"
 log = "0.4.20"
 log4rs = { version = "1.2.0", features = ["gzip"] }
 url = "2"
-aws_secretsmanager_caching = { version = "1.0.1", path = "../aws_secretsmanager_caching" }
+aws_secretsmanager_caching = { version = "1.1.0", path = "../aws_secretsmanager_caching" }
 
 # For unit tests
 [dev-dependencies]
@@ -37,3 +37,6 @@ aws-smithy-runtime = { version = "1", features = ["test-util"] }
 tokio = {version = "1", features = ["test-util", "rt-multi-thread", "net", "macros"] }
 http = "0.2.9"
 aws-smithy-types = "1"
+
+[features]
+prefer-post-quantum = ["aws_secretsmanager_caching/prefer-post-quantum"]

--- a/aws_secretsmanager_caching/Cargo.toml
+++ b/aws_secretsmanager_caching/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws_secretsmanager_caching"
-version = "1.0.1"
+version = "1.1.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "The AWS Secrets Manager Rust caching client enables in-process caching of secrets for Rust applications."
@@ -19,6 +19,7 @@ thiserror = "2"
 tokio = { version = "1", features = ["rt", "sync"] }
 linked-hash-map = "0.5.6"
 aws-config = "1"
+rustls = "*"
 
 [dev-dependencies]
 aws-smithy-mocks-experimental = "0"
@@ -27,3 +28,6 @@ aws-sdk-secretsmanager = { version = "1", features = ["test-util"] }
 tokio = { version = "1", features = ["macros", "rt", "sync", "test-util"] }
 http = "0"
 tokio-test = "0.4.4"
+
+[features]
+prefer-post-quantum = ["rustls/prefer-post-quantum"]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

https://docs.rs/rustls/0.23.23/rustls/manual/_05_defaults/index.html#about-the-post-quantum-secure-key-exchange-x25519mlkem768 added post-quantum support to the latest version of the AWS SDK for Rust.

Client Hellos

## Feature disabled

```
Transport Layer Security
    TLSv1.3 Record Layer: Handshake Protocol: Client Hello
...
            Extension: supported_groups (len=10)
                Type: supported_groups (10)
                Length: 10
                Supported Groups List Length: 8
                Supported Groups (4 groups)
                    Supported Group: x25519 (0x001d)
                    Supported Group: secp256r1 (0x0017)
                    Supported Group: secp384r1 (0x0018)
                    Supported Group: Unknown (0x11ec) # X25519MLKEM768
...
            Extension: key_share (len=38) x25519
                Type: key_share (51)
                Length: 38
                Key Share extension
                    Client Key Share Length: 36
                    Key Share Entry: Group: x25519, Key Exchange length: 32
                        Group: x25519 (29)
                        Key Exchange Length: 32
                        Key Exchange: 8e5ab7b9a9207bf923b6aaec193c58eef60089fec2732043fe4008005c1a0855
...
```

## Feature enabled

```
Transport Layer Security
    TLSv1.3 Record Layer: Handshake Protocol: Client Hello
...
                Supported Groups (4 groups)
                    Supported Group: Unknown (0x11ec) # X25519MLKEM768
                    Supported Group: x25519 (0x001d)
                    Supported Group: secp256r1 (0x0017)
                    Supported Group: secp384r1 (0x0018)
                Length: 2
                EC point formats Length: 1
                Elliptic curves point formats (1)
...
            Extension: key_share (len=1258) Unknown (4588), x25519
                Type: key_share (51)
                Length: 1258
                Key Share extension
                    Client Key Share Length: 1256
                    Key Share Entry: Group: Unknown (4588), Key Exchange length: 1216
                        Group: Unknown (4588)
                        Key Exchange Length: 1216
                        Key Exchange […]: d8e7561d77354cc40af135540dc3c7bbb3a1b01b3b68f982c3407ee36ab069fa66bcc9a086577980566163b44c3fcc25517b8fb1400cce1797dde540f8f1549704acbfe75b736c235d978b873aa807b29e0e2a2a7f77569ebb528478570ad28aae5075086a55766a2e309b28ed0
                    Key Share Entry: Group: x25519, Key Exchange length: 32
                        Group: x25519 (29) # Failover key in case Kyber negotiation fails
                        Key Exchange Length: 32
                        Key Exchange: 3f9608636b1b84e1374690f5496731ed1e123d5001111ff997d27caf3f83ea7d
...
```

Server responds with a PQ key

```
Extension: key_share (len=1124) Unknown (4588)
    Type: key_share (51)
    Length: 1124
    Key Share extension
        Key Share Entry: Group: Unknown (4588), Key Exchange length: 1120
            Group: Unknown (4588)
            Key Exchange Length: 1120
            Key Exchange […]: 6002508688562dca3240aa8831ff9517cb7018d515074cbdd6537799bde49d2361bc661cba9f0efcd2de0c2753134fe0bf71c5bd88b7db260918166525fcc4d8507adcd3d45296dfa7039568925f94eaf4117b2e60fdd82e19e60482370efe33631d7877bbf2af1e71d26029565
```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
