### PR TITLE
feat: add console logging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,7 @@ To change the configuration of the Secrets Manager Agent, create a [TOML](https:
 
 The following list shows the options you can configure for the Secrets Manager Agent\.
 + **log\_level** – The level of detail reported in logs for the Secrets Manager Agent: DEBUG, INFO, WARN, ERROR, or NONE\. The default is INFO\.
++ **log\_to\_file** - Whether to log to a file or stdout/stderr: `true` or `false`. The default is `true`.
 + **http\_port** – The port for the local HTTP server, in the range 1024 to 65535\. The default is 2773\.
 + **region** – The AWS Region to use for requests\. If no Region is specified, the Secrets Manager Agent determines the Region from the SDK\. For more information, see [Specify your credentials and default Region](https://docs.aws.amazon.com/sdk-for-rust/latest/dg/credentials.html) in the *AWS SDK for Rust Developer Guide*\.
 + **ttl\_seconds** – The TTL in seconds for the cached items, in the range 0 to 3600\. The default is 300\. 0 indicates that there is no caching\.
@@ -470,7 +471,7 @@ The Secrets Manager Agent can be built with optional features by passing the `--
 
 ## Logging<a name="secrets-manager-agent-log"></a>
 
-The Secrets Manager Agent logs errors locally to the file `logs/secrets_manager_agent.log`\. When your application calls the Secrets Manager Agent to get a secret, those calls appear in the local log\. They do not appear in the CloudTrail logs\. 
+The Secrets Manager Agent logs errors locally to the file `logs/secrets_manager_agent.log` or to stdout/stderr depending on the `log_to_file` config variable\. When your application calls the Secrets Manager Agent to get a secret, those calls appear in the local log\. They do not appear in the CloudTrail logs\. 
 
 The Secrets Manager Agent creates a new log file when the file reaches 10 MB, and it stores up to five log files total\. 
 

--- a/aws_secretsmanager_agent/src/config.rs
+++ b/aws_secretsmanager_agent/src/config.rs
@@ -402,7 +402,7 @@ mod tests {
     fn get_default_config_file() -> ConfigFile {
         ConfigFile {
             log_level: String::from(DEFAULT_LOG_LEVEL),
-            log_to_file: true,
+            log_to_file: DEFAULT_LOG_TO_FILE,
             http_port: String::from(DEFAULT_HTTP_PORT),
             ttl_seconds: String::from(DEFAULT_TTL_SECONDS),
             cache_size: String::from(DEFAULT_CACHE_SIZE),

--- a/aws_secretsmanager_agent/src/config.rs
+++ b/aws_secretsmanager_agent/src/config.rs
@@ -12,6 +12,7 @@ use std::str::FromStr;
 use std::time::Duration;
 
 const DEFAULT_LOG_LEVEL: &str = "info";
+const DEFAULT_LOG_TO_FILE: bool = true;
 const DEFAULT_HTTP_PORT: &str = "2773";
 const DEFAULT_TTL_SECONDS: &str = "300";
 const DEFAULT_CACHE_SIZE: &str = "1000";
@@ -33,6 +34,7 @@ const DEFAULT_REGION: Option<String> = None;
 #[serde(deny_unknown_fields)] // We want to error out when file has misspelled or unknown configurations.
 struct ConfigFile {
     log_level: String,
+    log_to_file: bool,
     http_port: String,
     ttl_seconds: String,
     cache_size: String,
@@ -76,6 +78,9 @@ impl FromStr for LogLevel {
 pub struct Config {
     /// The level of logging the agent provides ie. debug, info, warn, error or none.
     log_level: LogLevel,
+
+    // Whether to write logs to a file (default) or to stdout/stderr
+    log_to_file: bool,
 
     /// The port for the local HTTP server.
     http_port: u16,
@@ -135,6 +140,7 @@ impl Config {
         // Setting default configurations
         let mut config = ConfigLib::builder()
             .set_default("log_level", DEFAULT_LOG_LEVEL)?
+            .set_default("log_to_file", DEFAULT_LOG_TO_FILE)?
             .set_default("http_port", DEFAULT_HTTP_PORT)?
             .set_default("ttl_seconds", DEFAULT_TTL_SECONDS)?
             .set_default("cache_size", DEFAULT_CACHE_SIZE)?
@@ -168,6 +174,16 @@ impl Config {
     /// * `LogLevel` - The log level to use. Defaults to Info.
     pub fn log_level(&self) -> LogLevel {
         self.log_level
+    }
+
+    /// Whether to write logs to a file (default) or to stdout/stderr
+    ///
+    /// # Returns
+    ///
+    /// * `log_to_file` - `true` if writing logs to a file (default), `false` if writing logs to
+    /// stdout/stderr
+    pub fn log_to_file(&self) -> bool {
+        self.log_to_file
     }
 
     /// The port for the local HTTP server to listen for incomming requests.
@@ -278,6 +294,7 @@ impl Config {
         let config = Config {
             // Configurations that are allowed to be overridden.
             log_level: LogLevel::from_str(config_file.log_level.as_str())?,
+            log_to_file: config_file.log_to_file,
             http_port: parse_num::<u16>(
                 &config_file.http_port,
                 INVALID_HTTP_PORT_ERR_MSG,
@@ -385,6 +402,7 @@ mod tests {
     fn get_default_config_file() -> ConfigFile {
         ConfigFile {
             log_level: String::from(DEFAULT_LOG_LEVEL),
+            log_to_file: true,
             http_port: String::from(DEFAULT_HTTP_PORT),
             ttl_seconds: String::from(DEFAULT_TTL_SECONDS),
             cache_size: String::from(DEFAULT_CACHE_SIZE),

--- a/aws_secretsmanager_agent/src/logging.rs
+++ b/aws_secretsmanager_agent/src/logging.rs
@@ -1,5 +1,6 @@
 use crate::config::LogLevel;
 use log::{info, LevelFilter, SetLoggerError};
+use log4rs::append::console::ConsoleAppender;
 use log4rs::append::rolling_file::policy::compound::roll::fixed_window::FixedWindowRoller;
 use log4rs::append::rolling_file::policy::compound::trigger::size::SizeTrigger;
 use log4rs::append::rolling_file::policy::compound::CompoundPolicy;
@@ -26,6 +27,7 @@ const MAX_LOG_ARCHIVE_FILES: u32 = 5;
 const BYTES_PER_MB: u64 = 1024 * 1024;
 const MAX_ALLOWED_LOG_SIZE_IN_MB: u64 = 10;
 const FILE_APPENDER: &str = "FILE_APPENDER";
+const CONSOLE_APPENDER: &str = "CONSOLE_APPENDER";
 
 #[doc(hidden)]
 static STARTUP: Once = Once::new();
@@ -35,29 +37,56 @@ static STARTUP: Once = Once::new();
 /// # Arguments
 ///
 /// * `log_level` - The log level to report.
+/// * `log_to_file` - Whether to log to a file or stdout/stderr.
 ///
 /// # Returns
 ///
 /// * `Ok(())` - If no errors are encountered.
 /// * `Err(Error)` - For errors initializing the log.
-pub fn init_logger(log_level: LogLevel) -> Result<(), Box<dyn std::error::Error>> {
-    let fixed_window_roller =
-        FixedWindowRoller::builder().build(LOG_ARCHIVE_FILE_PATH_PATTERN, MAX_LOG_ARCHIVE_FILES)?;
-    let fixed_window_roller = Box::new(fixed_window_roller);
+pub fn init_logger(
+    log_level: LogLevel,
+    log_to_file: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let log_config: Config;
+    let mut logger_type: &str = "File";
 
-    let file_size_trigger = Box::new(SizeTrigger::new(MAX_ALLOWED_LOG_SIZE_IN_MB * BYTES_PER_MB));
-    let compound_policy = Box::new(CompoundPolicy::new(file_size_trigger, fixed_window_roller));
+    match log_to_file {
+        true => {
+            let fixed_window_roller = FixedWindowRoller::builder()
+                .build(LOG_ARCHIVE_FILE_PATH_PATTERN, MAX_LOG_ARCHIVE_FILES)?;
+            let fixed_window_roller = Box::new(fixed_window_roller);
 
-    let rolling_file_appender =
-        RollingFileAppender::builder().build(LOG_FILE_PATH, compound_policy)?;
+            let file_size_trigger =
+                Box::new(SizeTrigger::new(MAX_ALLOWED_LOG_SIZE_IN_MB * BYTES_PER_MB));
+            let compound_policy =
+                Box::new(CompoundPolicy::new(file_size_trigger, fixed_window_roller));
 
-    let log_config = Config::builder()
-        .appender(Appender::builder().build(FILE_APPENDER, Box::new(rolling_file_appender)))
-        .build(
-            Root::builder()
-                .appender(FILE_APPENDER)
-                .build(log_level.into()),
-        )?;
+            let rolling_file_appender =
+                RollingFileAppender::builder().build(LOG_FILE_PATH, compound_policy)?;
+
+            log_config = Config::builder()
+                .appender(Appender::builder().build(FILE_APPENDER, Box::new(rolling_file_appender)))
+                .build(
+                    Root::builder()
+                        .appender(FILE_APPENDER)
+                        .build(log_level.into()),
+                )?;
+        }
+        false => {
+            logger_type = "Console";
+
+            log_config = Config::builder()
+                .appender(Appender::builder().build(
+                    CONSOLE_APPENDER,
+                    Box::new(ConsoleAppender::builder().build()),
+                ))
+                .build(
+                    Root::builder()
+                        .appender(CONSOLE_APPENDER)
+                        .build(log_level.into()),
+                )?;
+        }
+    }
 
     // Don't initialize logging more than once in unit tests.
     let mut res: Option<SetLoggerError> = None;
@@ -70,7 +99,10 @@ pub fn init_logger(log_level: LogLevel) -> Result<(), Box<dyn std::error::Error>
         return Err(Box::new(err));
     }
 
-    info!("Logger initialized at `{:?}` log level.", log_level);
+    info!(
+        "{} logger initialized at `{:?}` log level.",
+        logger_type, log_level
+    );
     Ok(())
 }
 
@@ -80,10 +112,20 @@ mod tests {
     use crate::logging::init_logger;
     use log::{debug, error, info, warn, LevelFilter};
 
-    /// Tests that logger is getting initialized without errors.
+    /// Tests that file logger is getting initialized without errors.
     #[test]
-    fn test_init_logger() {
-        init_logger(LogLevel::Info).unwrap();
+    fn test_init_file_logger() {
+        init_logger(LogLevel::Info, true).unwrap();
+        debug!("{:?}", "Debug log");
+        error!("{:?}", "Error log");
+        info!("{:?}", "Info log");
+        warn!("{:?}", "Warn log");
+    }
+
+    /// Tests that console logger is getting initialized without errors.
+    #[test]
+    fn test_init_console_logger() {
+        init_logger(LogLevel::Info, false).unwrap();
         debug!("{:?}", "Debug log");
         error!("{:?}", "Error log");
         info!("{:?}", "Info log");


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
- Add a config variable called `log_to_file` (default `true`) which allows users to choose between writing logs to a file or stdout/stderr. This change allows the agent to work correctly with journald.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
