### PR TITLE
fix: use OIDC for Codecov

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build:
     strategy:
@@ -52,9 +56,8 @@ jobs:
         with:
           files: ./codecov.json
           fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
       - name: Lint
         run: cargo fmt --all -- --check
       - name: Clippy
         run: cargo clippy --all-targets --all-features
-


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Code coverage broke due to GitHub separating repository secrets from Dependabot secrets. Use the OIDC token to write code coverage data to Codecov.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
