### PR TITLE
Remove actions-rs/toolchain, cache dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        toolchain: [stable, nightly]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout 
@@ -36,8 +35,8 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Use Rust ${{ matrix.toolchain }}
-        run: rustup override set ${{ matrix.toolchain }}
+      - name: Use Rust stable
+        run: rustup override set stable
       - name: Rustup version
         run: rustup --version
       - name: Install Rust components

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,8 +35,6 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Use Rust stable
-        run: rustup override set stable
       - name: Rustup version
         run: rustup --version
       - name: Install Rust components

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,8 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Checkout 
+        uses: actions/checkout@v6
       - name: Restore cached dependencies
         uses: actions/cache/restore@v5
         id: cache-restore
@@ -54,8 +56,6 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: "stable"
-      - name: Checkout 
-        uses: actions/checkout@v6
       - name: Check licenses
         run: cargo-deny check licenses
       - name: Build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        toolchain: [stable, nightly]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout 
@@ -35,8 +36,8 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Use nightly
-        run: rustup override set nightly
+      - name: Use Rust ${{ matrix.toolchain }}
+        run: rustup override set ${{ matrix.toolchain }}
       - name: Rustup version
         run: rustup --version
       - name: Install Rust components

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,14 +22,27 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions-rs/toolchain@v1
+      - name: Restore cached dependencies
+        uses: actions/cache/restore@v5
+        id: cache-restore
         with:
-          toolchain: nightly
-          override: true
-          components: rustfmt, clippy, llvm-tools-preview
-      - name: Install cargo-llvm-cov
-        run: cargo install cargo-llvm-cov
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Use nightly
+        run: rustup override set nightly
+      - name: Rustup version
+        run: rustup --version
+      - name: Install Rust components
+        run: rustup component add llvm-tools clippy rustfmt cargo
+      - name: Install Cargo binaries
+        run: |
+          which cargo-llvm-cov || cargo install cargo-llvm-cov
+          which cargo-deny || cargo install cargo-deny
       - name: Install ninja-build tool for aws-lc-fips-sys on Windows
         if: runner.os == 'Windows'
         uses: seanmiddleditch/gha-setup-ninja@v6
@@ -41,10 +54,10 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: "stable"
+      - name: Checkout 
+        uses: actions/checkout@v6
       - name: Check licenses
-        run: |
-          cargo install cargo-deny
-          cargo-deny check licenses
+        run: cargo-deny check licenses
       - name: Build
         run: cargo build --verbose
       - name: Run tests
@@ -61,3 +74,14 @@ jobs:
         run: cargo fmt --all -- --check
       - name: Clippy
         run: cargo clippy --all-targets --all-features
+      - name: Cache dependencies
+        uses: actions/cache/save@v5
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}


### PR DESCRIPTION
## Description

https://github.com/actions/cache/blob/main/examples.md#rust---cargo

### Why is this change being made?

1. actions-rs/toolchain is no longer maintained and still on Node 20.
2. The cargo-deny step takes a long time because it has to fetch the dependencies, even if Cargo.lock has not changed since the last execution.


### What is changing?

1. Replace actions-rs/toolchain with rustup commands. rustup is provided on the GitHub hosted runners.
2. Cache rust dependencies and build artifacts on a hash of the Cargo.lock file.


### Related Links
- **Issue #, if available**:

---

## Testing

### How was this tested?

1. Tested on fork, reduces consecutive build times from 23 minutes to 3 minutes on Windows (the slowest build target).

### When testing locally, provide testing artifact(s):

1. First run: https://github.com/simonmarty/aws-secretsmanager-agent/actions/runs/23924128450
2. Second run: https://github.com/simonmarty/aws-secretsmanager-agent/actions/runs/23926285140

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [x] Build and Unit tests are passing
  *If not, why:*
- [x] Unit test coverage check is passing
  *If not, why:*
- [x] Integration tests pass locally
  *If not, why:*
- [x] I have updated integration tests (if needed)
  *If not, why:*
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [x] I have updated README/documentation (if needed)
  *If not, why:*
- [x] I have clearly called out breaking changes (if any)
  *If not, why:*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
