### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     strategy:
       matrix:
         runner: [ubuntu-latest, ubuntu-24.04-arm]

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,10 +6,11 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   build:
-    permissions:
-      contents: read
     strategy:
       matrix:
         runner: [ubuntu-latest, ubuntu-24.04-arm]


### PR DESCRIPTION
Potential fix for [https://github.com/aws/aws-secretsmanager-agent/security/code-scanning/3](https://github.com/aws/aws-secretsmanager-agent/security/code-scanning/3)

In general, this issue is fixed by explicitly declaring a `permissions` block in the workflow (either at the top level or per job) and setting it to the minimal scopes the workflow actually needs. For this Docker build workflow, the steps only need to read repository contents (for checkout); there is no need to write to the repo or interact with issues, PRs, or other resources, so `contents: read` is sufficient.

The best fix here is to add a job‑level `permissions` block under `jobs.build` (indented to align with `strategy:` and `runs-on:`) and set `contents: read`. This constrains the `GITHUB_TOKEN` used by this job without affecting other workflows. Concretely, edit `.github/workflows/docker.yml` and insert:

```yaml
    permissions:
      contents: read
```

between the `build:` line and the `strategy:` line (or between `runs-on:` and `steps:`; both are valid, but we’ll place it immediately after `build:` for clarity). No additional methods, imports, or definitions are required because this is purely a YAML configuration change for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
