### PR TITLE
Add benchmark regression detection with github-action-benchmark

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -18,20 +18,22 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v6
 
-      - name: Rustup version
-        run: rustup --version
+      - name: Log toolchain versions
+        run: rustc --version && cargo --version
 
       - name: Run benchmarks
         working-directory: aws_secretsmanager_caching
         run: cargo bench --bench benchmark -- --output-format bencher | tee ../bench-result.txt
 
-      - name: Download previous benchmark data
-        uses: actions/cache@v4
+      - name: Restore previous benchmark data
+        uses: actions/cache/restore@v4
         with:
           path: ./cache
-          key: ${{ runner.os }}-benchmark
+          key: benchmark-${{ github.sha }}
+          restore-keys: benchmark-
 
       - name: Compare benchmarks
         uses: benchmark-action/github-action-benchmark@v1
@@ -45,3 +47,10 @@ jobs:
           summary-always: true
           alert-threshold: '150%'
           fail-on-alert: true
+
+      - name: Save benchmark data
+        uses: actions/cache/save@v4
+        if: always()
+        with:
+          path: ./cache
+          key: benchmark-${{ github.sha }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -20,8 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+      - name: Rustup version
+        run: rustup --version
 
       - name: Run benchmarks
         working-directory: aws_secretsmanager_caching

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -22,18 +22,19 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Log toolchain versions
-        run: rustc --version && cargo --version
+        run: rustup --version && rustc --version && cargo --version
 
       - name: Run benchmarks
         working-directory: aws_secretsmanager_caching
         run: cargo bench --bench benchmark -- --output-format bencher | tee ../bench-result.txt
 
-      - name: Restore previous benchmark data
-        uses: actions/cache/restore@v4
+      - name: Download previous benchmark data
+        uses: actions/cache@v4
         with:
           path: ./cache
-          key: benchmark-${{ github.sha }}
-          restore-keys: benchmark-
+          key: benchmark-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            benchmark-${{ runner.os }}
 
       - name: Compare benchmarks
         uses: benchmark-action/github-action-benchmark@v1
@@ -47,10 +48,3 @@ jobs:
           summary-always: true
           alert-threshold: '150%'
           fail-on-alert: true
-
-      - name: Save benchmark data
-        uses: actions/cache/save@v4
-        if: always()
-        with:
-          path: ./cache
-          key: benchmark-${{ github.sha }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,11 +1,15 @@
 name: Benchmarks
 
 on:
-  workflow_dispatch:
   push:
-    branches: ["main"]
+    branches: [main]
   pull_request:
-    branches: ["main"]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -13,29 +17,31 @@ env:
 jobs:
   benchmark:
     runs-on: ubuntu-latest
-    
-    permissions:
-      contents: read
-    
     steps:
-    - name: Checkout
-      uses: actions/checkout@v6
-    
-    - name: Install Rust stable
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
-    
-    - name: Run benchmarks
-      working-directory: aws_secretsmanager_caching
-      run: cargo bench --bench benchmark
-    
-    - name: Upload benchmark results
-      if: always()
-      uses: actions/upload-artifact@v7
-      with:
-        name: benchmark-results-${{ github.sha }}
-        path: target/criterion/
-        if-no-files-found: error
-        retention-days: 30
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run benchmarks
+        working-directory: aws_secretsmanager_caching
+        run: cargo bench --bench benchmark -- --output-format bencher | tee ../bench-result.txt
+
+      - name: Download previous benchmark data
+        uses: actions/cache@v4
+        with:
+          path: ./cache
+          key: ${{ runner.os }}-benchmark
+
+      - name: Compare benchmarks
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Secrets Manager Agent Benchmarks
+          tool: cargo
+          output-file-path: bench-result.txt
+          external-data-json-path: ./cache/benchmark-data.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment-on-alert: true
+          summary-always: true
+          alert-threshold: '150%'
+          fail-on-alert: true


### PR DESCRIPTION
## Description

### Why is this change being made?
The existing benchmark workflow runs benchmarks and uploads results as artifacts, but never compares runs against each other. There is no automated way to detect performance regressions.

### What is changing?
Replaces the artifact-upload-only workflow with `benchmark-action/github-action-benchmark`, which:
- Stores benchmark results in a cache-based baseline
- Compares each new run against the previous baseline
- Fails the workflow if any benchmark regresses more than 50% (`alert-threshold: 150%`)
- Posts PR comments and job summaries when regressions are detected

Additional cleanup:
- Replaced deprecated `actions-rs/toolchain@v1` with `dtolnay/rust-toolchain@stable`
- Added `--output-format bencher` flag (required for Criterion output parsing)
- Added `pull-requests: write` permission for PR comment support

### How was this tested?
- Verified locally that `cargo bench --bench benchmark -- --output-format bencher` produces correct bencher-format output
- Validated YAML syntax
- The first run on `main` after merge will establish the baseline (no comparison). Every subsequent run will compare against it.