### PR TITLE
Add file-based credential support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,9 +64,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -369,14 +369,14 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 0.14.32",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.7",
+ "hyper-rustls 0.27.9",
  "hyper-util",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-native-certs",
  "rustls-pki-types",
  "serde",
@@ -542,7 +542,10 @@ dependencies = [
 name = "aws_secretsmanager_agent"
 version = "2.0.0"
 dependencies = [
+ "arc-swap",
  "aws-config",
+ "aws-credential-types",
+ "aws-runtime",
  "aws-sdk-secretsmanager",
  "aws-sdk-sts",
  "aws-smithy-runtime",
@@ -553,7 +556,7 @@ dependencies = [
  "config",
  "http 0.2.12",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "log",
  "log4rs",
@@ -561,6 +564,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "tempfile",
  "tokio",
  "url",
 ]
@@ -580,7 +584,7 @@ dependencies = [
  "linked-hash-map",
  "log",
  "rand",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "serde",
  "serde_json",
  "serde_with",
@@ -613,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
@@ -687,9 +691,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -750,9 +754,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
 ]
@@ -1178,9 +1182,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1203,6 +1207,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -1290,9 +1300,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1307,7 +1330,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1326,7 +1349,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1362,9 +1385,18 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -1374,6 +1406,12 @@ checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
  "hashbrown 0.14.5",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1495,9 +1533,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1510,7 +1548,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1533,16 +1570,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
@@ -1561,7 +1597,7 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -1598,12 +1634,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1611,9 +1648,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1624,9 +1661,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1638,15 +1675,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1658,15 +1695,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1676,6 +1713,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -1717,12 +1760,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1732,10 +1775,12 @@ name = "integration-tests"
 version = "0.1.0"
 dependencies = [
  "aws-config",
+ "aws-credential-types",
  "aws-sdk-secretsmanager",
  "derive_builder",
  "reqwest",
  "serde_json",
+ "tempfile",
  "tokio",
  "url",
 ]
@@ -1748,9 +1793,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -1794,10 +1839,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1820,10 +1867,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.183"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.185"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "linked-hash-map"
@@ -1832,10 +1885,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
-name = "litemap"
-version = "0.8.1"
+name = "linux-raw-sys"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -2172,9 +2231,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2215,6 +2274,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2235,7 +2304,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "socket2 0.6.3",
  "thiserror",
  "tokio",
@@ -2255,7 +2324,7 @@ dependencies = [
  "rand",
  "ring",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-pki-types",
  "slab",
  "thiserror",
@@ -2294,10 +2363,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.9.2"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -2324,9 +2399,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -2418,15 +2493,15 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper 1.9.0",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2491,9 +2566,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -2502,6 +2577,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2518,16 +2606,16 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.12",
  "subtle",
  "zeroize",
 ]
@@ -2566,9 +2654,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2671,9 +2759,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "separator"
@@ -2727,7 +2815,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -2766,7 +2854,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -2793,7 +2881,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -2935,6 +3023,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3024,9 +3125,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3059,9 +3160,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",
@@ -3075,9 +3176,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3100,7 +3201,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "tokio",
 ]
 
@@ -3166,7 +3267,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3452,10 +3553,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.114"
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3466,23 +3576,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3490,9 +3596,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3503,18 +3609,52 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.91"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3799,12 +3939,94 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.14.0",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xmlparser"
@@ -3831,9 +4053,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3842,9 +4064,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3854,18 +4076,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3874,18 +4096,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3901,9 +4123,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -3912,9 +4134,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3923,9 +4145,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ To download the source code, see [https://github\.com/aws/aws\-secretsmanager\-a
       - [\[ curl \]](#-curl--1)
       - [\[ Python \]](#-python--1)
   - [Configure the Secrets Manager Agent](#configure-the-secrets-manager-agent)
+  - [File-based credentials](#file-based-credentials)
   - [Logging](#logging)
   - [Security considerations](#security-considerations)
   - [Running Integration Tests Locally](#running-integration-tests-locally)
@@ -468,6 +469,60 @@ The following list shows the options you can configure for the Secrets Manager A
 + **ssrf\_env\_variables** – A list of environment variable names the Secrets Manager Agent checks in sequential order for the SSRF token\. The environment variable can contain the token or a reference to the token file as in: `AWS_TOKEN=file:///var/run/awssmatoken`\. The default is "AWS\_TOKEN, AWS\_SESSION\_TOKEN, AWS\_CONTAINER\_AUTHORIZATION\_TOKEN\".
 + **path\_prefix** – The URI prefix used to determine if the request is a path based request\. The default is "/v1/"\.
 + **max\_conn** – The maximum number of connections from HTTP clients that the Secrets Manager Agent allows, in the range 1 to 1000\. The default is 800\.
++ **credentials\_file\_path** – The path to a file containing AWS credentials in the standard AWS credentials file format. When set, the agent reads credentials from this file instead of using the default SDK credential provider chain. The agent automatically reloads credentials when the file changes, making it compatible with credential rotation systems that deliver refreshed credentials to the filesystem. This parameter is optional.
+
+## File-based credentials
+
+By default, the Secrets Manager Agent uses the [AWS SDK default credential provider chain](https://docs.aws.amazon.com/sdk-for-rust/latest/dg/credproviders.html) to authenticate with Secrets Manager. This works well on Amazon EC2 (via IMDS), Lambda, and ECS/EKS (via container credentials).
+
+For environments where credentials are delivered to the filesystem — such as on-premises hosts using [IAM Roles Anywhere](https://docs.aws.amazon.com/rolesanywhere/latest/userguide/introduction.html) or other credential management systems — you can configure the agent to read credentials from a file.
+
+### Credentials file format
+
+The credentials file must use the standard AWS credentials file format:
+
+```
+[default]
+aws_access_key_id = AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+aws_session_token = IQoJb3JpZ2luX2Vj...
+```
+
+### Configuration
+
+Set the `credentials_file_path` parameter in your configuration file:
+
+```toml
+region = "us-east-1"
+credentials_file_path = "/path/to/credentials"
+```
+
+### Credential refresh behavior
+
+The agent automatically detects and re-reads updated credentials from the file:
+
++ The agent checks the credentials file for changes every 5 minutes.
++ When the file's modification time changes, the agent reloads the credentials.
++ If the file is missing or malformed during a reload, the agent continues using the previously cached credentials and retries on the next cycle.
++ Credentials are served to the AWS SDK with a 10-minute expiry window, ensuring the SDK periodically requests fresh credentials from the provider.
+
+### Startup behavior
+
+The agent is designed to start successfully regardless of the credentials file state:
+
++ If the file exists and contains valid credentials, the agent loads them immediately.
++ If the file is missing, empty, or malformed, the agent starts without credentials and the background reload task will pick up valid credentials when they appear.
++ When file-based credentials are configured, the agent skips the STS credential validation check at startup, since the credentials file may not yet exist. The `validate_credentials` setting continues to apply for non-file-based credential sources.
++ Calls to Secrets Manager will fail until valid credentials are available. The agent process itself remains running and will begin serving requests once credentials appear in the file.
+
+### Security
+
+On Unix systems, the agent logs a warning if the credentials file has permissions more permissive than owner-only (`0600`). Consider restricting file permissions:
+
+```sh
+chmod 600 /path/to/credentials
+```
+
 
 ## Logging<a name="secrets-manager-agent-log"></a>
 
@@ -541,3 +596,4 @@ The integration tests are organized into the following modules:
 - **`security.rs`** - Tests security features including SSRF token validation and X-Forwarded-For header rejection
 - **`version_management.rs`** - Tests secret version transitions and rotation scenarios
 - **`configuration.rs`** - Tests configuration parameters including health checks and path-based requests
+- **`file_credentials.rs`** - Tests file-based credential loading including valid/invalid/missing credentials, self-healing (credentials appearing after startup), and credential rotation

--- a/aws_secretsmanager_agent/Cargo.toml
+++ b/aws_secretsmanager_agent/Cargo.toml
@@ -22,9 +22,12 @@ serde_derive = "1"
 config = "0.14"
 
 aws-config = "1"
+aws-credential-types = "1"
+aws-runtime = "1"
 aws-sdk-secretsmanager = "1"
 aws-smithy-runtime-api = "1"
 aws-sdk-sts = "1"
+arc-swap = "1"
 log = "0.4.29"
 log4rs = { version = "1.2.0", features = ["gzip"] }
 url = "2"
@@ -37,3 +40,4 @@ aws-smithy-runtime = { version = "1", features = ["test-util"] }
 tokio = { version = "1", features = ["test-util", "rt-multi-thread", "net", "macros"] }
 http = "0.2.9"
 aws-smithy-types = "1"
+tempfile = "3"

--- a/aws_secretsmanager_agent/src/cache_manager.rs
+++ b/aws_secretsmanager_agent/src/cache_manager.rs
@@ -29,8 +29,9 @@ use tests::init_client as asm_client;
 impl CacheManager {
     /// Create a new CacheManager. For simplicity I'm propagating the errors back up for now.
     pub async fn new(cfg: &Config) -> Result<Self, Box<dyn std::error::Error>> {
+        let (client, _sdk_config) = asm_client(cfg).await?; // sdk_config reserved for future use
         Ok(Self(SecretsManagerCachingClient::new(
-            asm_client(cfg).await?,
+            client,
             cfg.cache_size(),
             cfg.ttl(),
             cfg.ignore_transient_errors(),
@@ -233,8 +234,8 @@ pub mod tests {
     // Used to replace the real client with the stub client.
     pub async fn init_client(
         _cfg: &Config,
-    ) -> Result<secretsmanager::Client, Box<dyn std::error::Error>> {
-        Ok(CLIENT.with_borrow(|v| v.clone()))
+    ) -> Result<(secretsmanager::Client, ()), Box<dyn std::error::Error>> {
+        Ok((CLIENT.with_borrow(|v| v.clone()), ()))
     }
 
     // Private helper to look at the request and provide the correct reponse.

--- a/aws_secretsmanager_agent/src/config.rs
+++ b/aws_secretsmanager_agent/src/config.rs
@@ -8,6 +8,7 @@ use config::File;
 use serde_derive::Deserialize;
 use std::num::NonZeroUsize;
 use std::ops::Range;
+use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -45,6 +46,7 @@ struct ConfigFile {
     region: Option<String>,
     ignore_transient_errors: bool,
     validate_credentials: bool,
+    credentials_file_path: Option<PathBuf>,
 }
 
 /// The log levels supported by the daemon.
@@ -112,6 +114,9 @@ pub struct Config {
 
     /// Whether the agent should validate AWS credentials at startup
     validate_credentials: bool,
+
+    /// Optional path to a credentials file for file-based credential loading.
+    credentials_file_path: Option<PathBuf>,
 }
 
 /// The default configuration options.
@@ -156,7 +161,8 @@ impl Config {
             .set_default("max_conn", DEFAULT_MAX_CONNECTIONS)?
             .set_default("region", DEFAULT_REGION)?
             .set_default("ignore_transient_errors", DEFAULT_IGNORE_TRANSIENT_ERRORS)?
-            .set_default("validate_credentials", DEFAULT_STS_CHECK)?;
+            .set_default("validate_credentials", DEFAULT_STS_CHECK)?
+            .set_default("credentials_file_path", None::<String>)?;
 
         // Merge the config overrides onto the default configurations, if provided.
         config = match file_path {
@@ -278,6 +284,15 @@ impl Config {
         self.validate_credentials
     }
 
+    /// Optional path to a credentials file for file-based credential loading.
+    ///
+    /// # Returns
+    ///
+    /// * `Option<&PathBuf>` - The path to the credentials file, or None.
+    pub fn credentials_file_path(&self) -> Option<&PathBuf> {
+        self.credentials_file_path.as_ref()
+    }
+
     /// Private helper that fills in the Config instance from the specified
     /// config overrides (or defaults).
     ///
@@ -328,6 +343,7 @@ impl Config {
             region: config_file.region,
             ignore_transient_errors: config_file.ignore_transient_errors,
             validate_credentials: config_file.validate_credentials,
+            credentials_file_path: config_file.credentials_file_path,
         };
 
         // Additional validations.
@@ -413,6 +429,7 @@ mod tests {
             region: None,
             ignore_transient_errors: DEFAULT_IGNORE_TRANSIENT_ERRORS,
             validate_credentials: DEFAULT_STS_CHECK,
+            credentials_file_path: None,
         }
     }
 
@@ -440,6 +457,7 @@ mod tests {
         assert_eq!(config.clone().region(), None);
         assert!(config.ignore_transient_errors());
         assert!(config.validate_credentials());
+        assert_eq!(config.credentials_file_path(), None);
     }
 
     /// Tests the config overrides are applied correctly from the provided config file.
@@ -466,6 +484,10 @@ mod tests {
         assert_eq!(config.clone().region(), Some(&"us-west-2".to_string()));
         assert!(!config.ignore_transient_errors());
         assert!(!config.validate_credentials());
+        assert_eq!(
+            config.credentials_file_path(),
+            Some(&PathBuf::from("/tmp/test_credentials"))
+        );
     }
 
     /// Tests that an Err is returned when an invalid value is provided in one of the configurations.

--- a/aws_secretsmanager_agent/src/constants.rs
+++ b/aws_secretsmanager_agent/src/constants.rs
@@ -23,5 +23,5 @@ pub const VERSION: Option<&'static str> = option_env!("CARGO_PKG_VERSION");
 pub const DEFAULT_MAX_CONNECTIONS: &str = "800";
 // The max request time
 pub const MAX_REQ_TIME_SEC: u64 = 61;
-// The max buffer size
-pub const MAX_BUF_BYTES: usize = (65 + 256) * 1024; // 321 KB
+// The max buffer size (321 KB)
+pub const MAX_BUF_BYTES: usize = (65 + 256) * 1024;

--- a/aws_secretsmanager_agent/src/credentials_file_provider.rs
+++ b/aws_secretsmanager_agent/src/credentials_file_provider.rs
@@ -1,0 +1,382 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use arc_swap::ArcSwapOption;
+use aws_config::profile::ProfileFileCredentialsProvider;
+use aws_credential_types::provider::{error::CredentialsError, future, ProvideCredentials};
+use aws_credential_types::Credentials;
+use aws_runtime::env_config::file::{EnvConfigFileKind, EnvConfigFiles};
+use tokio::task::JoinHandle;
+
+/// How often the background task checks for updated credentials on disk.
+fn reload_delay() -> Duration {
+    #[cfg(debug_assertions)]
+    if let Ok(secs) = std::env::var("SMA_CREDENTIALS_RELOAD_SECS") {
+        if let Ok(val) = secs.parse() {
+            return Duration::from_secs(val);
+        }
+    }
+    Duration::from_secs(5 * 60)
+}
+
+/// How long the SDK considers the credentials valid before asking the provider again.
+/// Set below the minimum AssumeRole duration (15 min) to provide buffer for short-lived credentials.
+const SDK_CREDENTIALS_TTL: Duration = Duration::from_secs(10 * 60);
+
+/// A credentials provider that reads AWS credentials from a file and
+/// automatically reloads them on a configurable interval.
+///
+/// The credentials file must be in the standard AWS credentials file format:
+/// ```text
+/// [default]
+/// aws_access_key_id = AKIAIOSFODNN7EXAMPLE
+/// aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+/// aws_session_token = FwoGZX...
+/// ```
+#[derive(Debug, Clone)]
+pub struct FileBasedCredentialsProvider {
+    cached: Arc<ArcSwapOption<Credentials>>,
+    _reload_handle: Arc<ReloadHandle>,
+}
+
+/// Aborts the background reload task when dropped.
+#[derive(Debug)]
+struct ReloadHandle(JoinHandle<()>);
+
+impl Drop for ReloadHandle {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+impl FileBasedCredentialsProvider {
+    /// Create a new provider that reads credentials from the given path.
+    ///
+    /// Attempts an initial load but does not fail if the file is missing,
+    /// empty, or malformed — the agent can still serve cached secrets and
+    /// the background reload task will pick up valid credentials when they
+    /// appear.
+    pub async fn new(path: impl Into<PathBuf>) -> Self {
+        let path = path.into();
+        let cached = Arc::new(ArcSwapOption::new(None));
+
+        // Attempt initial load — log warnings on failure instead of failing.
+        match load_from_file(&path).await {
+            Ok(creds) => {
+                cached.store(Some(Arc::new(creds)));
+                warn_if_broad_permissions(&path);
+                log::info!("Loaded file-based credentials from: {}", path.display());
+            }
+            Err(e) => {
+                log::warn!(
+                    "Could not load credentials from {}: {}. \
+                     The agent will retry every {} seconds.",
+                    path.display(),
+                    e,
+                    reload_delay().as_secs()
+                );
+            }
+        }
+
+        // Start background reload
+        let reload_cached = cached.clone();
+        let handle = tokio::spawn(async move {
+            let mut last_modified = file_modified_time(&path);
+            let mut interval = tokio::time::interval(reload_delay());
+            interval.tick().await; // skip the immediate first tick
+            loop {
+                interval.tick().await;
+
+                let current_modified = file_modified_time(&path);
+                if current_modified == last_modified {
+                    continue;
+                }
+
+                match load_from_file(&path).await {
+                    Ok(creds) => {
+                        reload_cached.store(Some(Arc::new(creds)));
+                        last_modified = current_modified;
+                        warn_if_broad_permissions(&path);
+                        log::debug!("Successfully reloaded credentials from {}", path.display());
+                    }
+                    Err(e) => {
+                        // Do not update last_modified here — if the file was
+                        // partially written, we want to retry on the next cycle
+                        // even if the mtime hasn't changed again.
+                        log::warn!(
+                            "Failed to reload credentials from {}: {}",
+                            path.display(),
+                            e
+                        );
+                    }
+                }
+            }
+        });
+
+        Self {
+            cached,
+            _reload_handle: Arc::new(ReloadHandle(handle)),
+        }
+    }
+}
+
+impl ProvideCredentials for FileBasedCredentialsProvider {
+    fn provide_credentials<'a>(&'a self) -> future::ProvideCredentials<'a>
+    where
+        Self: 'a,
+    {
+        future::ProvideCredentials::new(async {
+            self.cached
+                .load()
+                .as_ref()
+                .map(|c| with_expiry((**c).clone()))
+                .ok_or_else(|| CredentialsError::not_loaded("No credentials available"))
+        })
+    }
+}
+
+/// Parse credentials from a file using the AWS SDK's profile file parser.
+async fn load_from_file(path: &Path) -> Result<Credentials, CredentialsError> {
+    let env_config_files = EnvConfigFiles::builder()
+        .with_file(EnvConfigFileKind::Credentials, path)
+        .build();
+
+    ProfileFileCredentialsProvider::builder()
+        .profile_files(env_config_files)
+        .build()
+        .provide_credentials()
+        .await
+}
+
+/// Wrap credentials with an SDK expiry so the SDK knows when to ask again.
+fn with_expiry(creds: Credentials) -> Credentials {
+    Credentials::new(
+        creds.access_key_id(),
+        creds.secret_access_key(),
+        creds.session_token().map(|s| s.to_string()),
+        Some(SystemTime::now() + SDK_CREDENTIALS_TTL),
+        "FileBasedCredentialsProvider",
+    )
+}
+
+fn file_modified_time(path: &Path) -> Option<SystemTime> {
+    std::fs::metadata(path).and_then(|m| m.modified()).ok()
+}
+
+/// Log a warning if the credentials file has permissions more permissive than owner-only (0600).
+#[cfg(unix)]
+fn warn_if_broad_permissions(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    if let Ok(metadata) = std::fs::metadata(path) {
+        let mode = metadata.permissions().mode();
+        if mode & 0o077 != 0 {
+            log::warn!(
+                "Credentials file {} has broad permissions ({:o}). \
+                 Consider restricting to owner-only (chmod 600).",
+                path.display(),
+                mode & 0o777
+            );
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn warn_if_broad_permissions(_path: &Path) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_fake_credentials(file: &mut NamedTempFile) {
+        writeln!(
+            file,
+            "[default]\naws_access_key_id=AKIAIOSFODNN7EXAMPLE\naws_secret_access_key=wJalrXUtnFEMI\naws_session_token=FwoGZX"
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_load_valid_credentials() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        write_fake_credentials(&mut tmp);
+
+        let provider = FileBasedCredentialsProvider::new(tmp.path()).await;
+        let creds = provider.provide_credentials().await.unwrap();
+
+        assert_eq!(creds.access_key_id(), "AKIAIOSFODNN7EXAMPLE");
+        assert_eq!(creds.secret_access_key(), "wJalrXUtnFEMI");
+        assert_eq!(creds.session_token(), Some("FwoGZX"));
+    }
+
+    #[tokio::test]
+    async fn test_missing_file_starts_with_empty_cache() {
+        let provider = FileBasedCredentialsProvider::new("/nonexistent/path").await;
+        let result = provider.provide_credentials().await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_empty_file_starts_with_empty_cache() {
+        let tmp = NamedTempFile::new().unwrap();
+        let provider = FileBasedCredentialsProvider::new(tmp.path()).await;
+        let result = provider.provide_credentials().await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_credential_reload() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        write_fake_credentials(&mut tmp);
+
+        let provider = FileBasedCredentialsProvider::new(tmp.path()).await;
+        assert_eq!(
+            provider
+                .provide_credentials()
+                .await
+                .unwrap()
+                .access_key_id(),
+            "AKIAIOSFODNN7EXAMPLE"
+        );
+
+        // Real sleep to let the background task reach its interval.tick().await
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        // Simulate credential rotation
+        std::fs::write(
+            tmp.path(),
+            "[default]\naws_access_key_id=ROTATED_KEY\naws_secret_access_key=secret\naws_session_token=token",
+        )
+        .unwrap();
+
+        // Bump mtime so the reload detects a change
+        tmp.as_file()
+            .set_modified(SystemTime::now() + Duration::from_secs(60))
+            .unwrap();
+
+        // Advance past the reload delay, then resume and let the async
+        // ProfileFileCredentialsProvider complete. Per tokio docs, advance()
+        // "will not wait for the sleep calls it advanced past to complete"
+        // so we resume real time and sleep to let all async work finish.
+        tokio::time::pause();
+        tokio::time::advance(reload_delay()).await;
+        tokio::time::resume();
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        assert_eq!(
+            provider
+                .provide_credentials()
+                .await
+                .unwrap()
+                .access_key_id(),
+            "ROTATED_KEY"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_permission_change_retains_cached_credentials() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut tmp = NamedTempFile::new().unwrap();
+        write_fake_credentials(&mut tmp);
+
+        let provider = FileBasedCredentialsProvider::new(tmp.path()).await;
+        assert_eq!(
+            provider
+                .provide_credentials()
+                .await
+                .unwrap()
+                .access_key_id(),
+            "AKIAIOSFODNN7EXAMPLE"
+        );
+
+        // Write to the file to bump mtime so the reload task detects a change
+        std::fs::write(tmp.path(), "invalid").unwrap();
+        // Now remove read permission so load_from_file fails
+        std::fs::set_permissions(tmp.path(), std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        // Real sleep to let the background task reach its interval.tick().await
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        // Trigger reload cycle
+        tokio::time::pause();
+        tokio::time::advance(reload_delay()).await;
+        tokio::time::resume();
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        // Cached credentials should still be available
+        assert_eq!(
+            provider
+                .provide_credentials()
+                .await
+                .unwrap()
+                .access_key_id(),
+            "AKIAIOSFODNN7EXAMPLE"
+        );
+
+        // Restore permissions for cleanup
+        std::fs::set_permissions(tmp.path(), std::fs::Permissions::from_mode(0o644)).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_failed_reload_then_valid_creds_same_mtime() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        write_fake_credentials(&mut tmp);
+
+        let provider = FileBasedCredentialsProvider::new(tmp.path()).await;
+        assert_eq!(
+            provider
+                .provide_credentials()
+                .await
+                .unwrap()
+                .access_key_id(),
+            "AKIAIOSFODNN7EXAMPLE"
+        );
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        // Write invalid content with a known mtime
+        let bad_mtime = SystemTime::now() + Duration::from_secs(120);
+        std::fs::write(tmp.path(), "not valid credentials").unwrap();
+        tmp.as_file().set_modified(bad_mtime).unwrap();
+
+        tokio::time::pause();
+        tokio::time::advance(reload_delay()).await;
+        tokio::time::resume();
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        assert_eq!(
+            provider
+                .provide_credentials()
+                .await
+                .unwrap()
+                .access_key_id(),
+            "AKIAIOSFODNN7EXAMPLE"
+        );
+
+        // Write valid credentials with the SAME mtime
+        std::fs::write(
+            tmp.path(),
+            "[default]\naws_access_key_id=RECOVERED_KEY\naws_secret_access_key=secret\naws_session_token=token",
+        )
+        .unwrap();
+        tmp.as_file().set_modified(bad_mtime).unwrap();
+
+        tokio::time::pause();
+        tokio::time::advance(reload_delay()).await;
+        tokio::time::resume();
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        assert_eq!(
+            provider
+                .provide_credentials()
+                .await
+                .unwrap()
+                .access_key_id(),
+            "RECOVERED_KEY",
+        );
+    }
+}

--- a/aws_secretsmanager_agent/src/main.rs
+++ b/aws_secretsmanager_agent/src/main.rs
@@ -11,6 +11,7 @@ mod server;
 use server::Server;
 mod config;
 mod constants;
+pub mod credentials_file_provider;
 mod logging;
 mod utils;
 

--- a/aws_secretsmanager_agent/src/utils.rs
+++ b/aws_secretsmanager_agent/src/utils.rs
@@ -6,6 +6,8 @@ use aws_sdk_secretsmanager::config::{ConfigBag, Intercept, RuntimeComponents};
 use aws_sdk_secretsmanager::Client as SecretsManagerClient;
 use std::env::VarError;
 use std::fs;
+#[cfg(not(test))]
+use std::path::PathBuf;
 use std::time::Duration;
 
 #[cfg(not(test))]
@@ -114,26 +116,54 @@ pub fn time_out_test() -> Duration {
 ///
 /// # Returns
 ///
-/// * `Ok(SecretsManagerClient)` - An AWS Secrets Manager client if the credentials are valid.
+/// * `Ok((SecretsManagerClient, SdkConfig))` - An AWS Secrets Manager client and the SDK config
+///   (with file-based credentials wired in, if applicable). The SDK config can be reused by
+///   other components that need the same credential source (e.g., AssumeRole for cross-account access).
 /// * `Err(Box<dyn std::error::Error>)` if there is an error creating the Secrets Manager client
 ///   or validating the AWS credentials.
 #[doc(hidden)]
 #[cfg(not(test))]
 pub async fn validate_and_create_asm_client(
     config: &Config,
-) -> Result<SecretsManagerClient, Box<dyn std::error::Error>> {
+) -> Result<(SecretsManagerClient, aws_config::SdkConfig), Box<dyn std::error::Error>> {
+    use crate::credentials_file_provider::FileBasedCredentialsProvider;
     use aws_config::{BehaviorVersion, Region};
     use aws_secretsmanager_caching::error::is_transient_error;
-    let default_config = &aws_config::load_defaults(BehaviorVersion::latest()).await;
-    let mut asm_builder = aws_sdk_secretsmanager::config::Builder::from(default_config)
+
+    let mut sdk_config = aws_config::load_defaults(BehaviorVersion::latest()).await;
+
+    // Use file-based credentials if configured.
+    let has_file_provider = if let Some(path) = discover_credentials_file(config) {
+        log::info!("Using file-based credentials from: {}", path.display());
+        let provider = FileBasedCredentialsProvider::new(&path).await;
+        sdk_config = sdk_config
+            .into_builder()
+            .credentials_provider(
+                aws_credential_types::provider::SharedCredentialsProvider::new(provider),
+            )
+            .build();
+        true
+    } else {
+        log::info!("No credentials file found, using default SDK credential chain");
+        false
+    };
+
+    let mut asm_builder = aws_sdk_secretsmanager::config::Builder::from(&sdk_config)
         .interceptor(AgentModifierInterceptor);
+
+    #[cfg(debug_assertions)]
+    if std::env::var("SMA_DISABLE_IDENTITY_CACHE").is_ok() {
+        log::info!("Identity caching disabled via SMA_DISABLE_IDENTITY_CACHE");
+        asm_builder =
+            asm_builder.identity_cache(aws_sdk_secretsmanager::config::IdentityCache::no_cache());
+    }
 
     if let Some(region) = config.region() {
         asm_builder.set_region(Some(Region::new(region.clone())));
     }
 
-    if config.validate_credentials() {
-        let mut sts_builder = aws_sdk_sts::config::Builder::from(default_config);
+    if config.validate_credentials() && !has_file_provider {
+        let mut sts_builder = aws_sdk_sts::config::Builder::from(&sdk_config);
         if let Some(region) = config.region() {
             sts_builder.set_region(Some(Region::new(region.clone())));
         }
@@ -144,11 +174,36 @@ pub async fn validate_and_create_asm_client(
             Err(e) if config.ignore_transient_errors() && is_transient_error(&e) => (),
             Err(e) => Err(e)?,
         };
+    } else if has_file_provider {
+        log::info!("Skipping STS credential validation for file-based credentials");
     }
 
-    Ok(aws_sdk_secretsmanager::Client::from_conf(
-        asm_builder.build(),
+    Ok((
+        aws_sdk_secretsmanager::Client::from_conf(asm_builder.build()),
+        sdk_config,
     ))
+}
+
+/// Discover a credentials file from explicit config.
+///
+/// Returns the configured credentials file path, if set.
+/// If the configured path does not exist yet, it is still returned — the provider
+/// will start with an empty cache and the background reload will pick up the file
+/// when it appears.
+#[cfg(not(test))]
+fn discover_credentials_file(config: &Config) -> Option<PathBuf> {
+    if let Some(path) = config.credentials_file_path() {
+        if !path.is_file() {
+            log::warn!(
+                "Configured credentials_file_path does not exist yet: {}. \
+                 The agent will watch for it to appear.",
+                path.display()
+            );
+        }
+        return Some(path.clone());
+    }
+
+    None
 }
 
 /// SDK interceptor to append the agent name and version to the User-Agent header for CloudTrail records.

--- a/aws_secretsmanager_agent/tests/resources/configs/config_file_valid.toml
+++ b/aws_secretsmanager_agent/tests/resources/configs/config_file_valid.toml
@@ -12,3 +12,4 @@ max_conn = 10
 region = "us-west-2"
 ignore_transient_errors = false
 validate_credentials = false
+credentials_file_path = "/tmp/test_credentials"

--- a/deny.toml
+++ b/deny.toml
@@ -11,4 +11,5 @@ allow = [
     "OpenSSL",
     "0BSD",
     "CDLA-Permissive-2.0",
+    "CC0-1.0",
 ]

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -13,4 +13,6 @@ aws-config = "1"
 aws-sdk-secretsmanager = "1"
 url = "2"
 derive_builder = "0.20"
+tempfile = "3"
+aws-credential-types = "1"
 

--- a/integration-tests/tests/common.rs
+++ b/integration-tests/tests/common.rs
@@ -7,7 +7,6 @@
 use aws_config;
 use aws_sdk_secretsmanager;
 use derive_builder::Builder;
-use std::env;
 use std::fmt;
 use std::path::PathBuf;
 use std::process::Stdio;
@@ -91,11 +90,45 @@ validate_credentials = true
 "#,
             port, ttl_seconds
         );
+        Self::spawn_agent(&config_content, port, &[]).await
+    }
 
+    #[allow(dead_code)]
+    pub async fn start_with_credentials_file(
+        port: u16,
+        credentials_file_path: Option<&str>,
+    ) -> AgentProcess {
+        Self::start_with_credentials_file_and_env(port, credentials_file_path, &[]).await
+    }
+
+    #[allow(dead_code)]
+    pub async fn start_with_credentials_file_and_env(
+        port: u16,
+        credentials_file_path: Option<&str>,
+        extra_env: &[(&str, &str)],
+    ) -> AgentProcess {
+        let creds_line = match credentials_file_path {
+            Some(path) => format!("credentials_file_path = \"{}\"", path),
+            None => String::new(),
+        };
+        let config_content = format!(
+            r#"
+http_port = {}
+log_level = "debug"
+{}
+"#,
+            port, creds_line
+        );
+        Self::spawn_agent(&config_content, port, extra_env).await
+    }
+
+    async fn spawn_agent(
+        config_content: &str,
+        port: u16,
+        extra_env: &[(&str, &str)],
+    ) -> AgentProcess {
         let config_path = format!("/tmp/test_config_{}.toml", port);
         std::fs::write(&config_path, config_content).expect("Failed to write test config");
-
-        env::set_var("AWS_TOKEN", "test-token-123");
 
         let possible_paths = [
             PathBuf::from("target")
@@ -119,16 +152,20 @@ validate_credentials = true
             .find(|path| path.exists())
             .expect("Agent binary not found");
 
-        let mut child = TokioCommand::new(agent_path)
-            .arg("--config")
+        let mut cmd = TokioCommand::new(agent_path);
+        cmd.arg("--config")
             .arg(&config_path)
+            .env("AWS_TOKEN", "test-token-123")
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
-            .kill_on_drop(true)
-            .spawn()
-            .expect("Failed to start agent");
+            .kill_on_drop(true);
 
-        // Read stdout until we see the "listening" message
+        for (key, val) in extra_env {
+            cmd.env(key, val);
+        }
+
+        let mut child = cmd.spawn().expect("Failed to start agent");
+
         let stdout = child.stdout.take().expect("Failed to get stdout");
         let mut reader = BufReader::new(stdout).lines();
 
@@ -138,12 +175,8 @@ validate_credentials = true
                     panic!("Agent failed to start - no listening message found");
                 }
             }
-            Ok(None) => {
-                panic!("Stream ended without finding listening message");
-            }
-            Err(e) => {
-                panic!("Failed to read agent output: {}", e);
-            }
+            Ok(None) => panic!("Stream ended without finding listening message"),
+            Err(e) => panic!("Failed to read agent output: {}", e),
         }
 
         AgentProcess {

--- a/integration-tests/tests/file_credentials.rs
+++ b/integration-tests/tests/file_credentials.rs
@@ -1,0 +1,323 @@
+//! # File-Based Credentials Integration Tests
+//!
+//! Tests for the FileBasedCredentialsProvider feature, verifying the agent
+//! correctly handles various credential file scenarios.
+//!
+//! **Note:** `test_self_healing_credentials_appear_after_startup` uses
+//! `SMA_CREDENTIALS_RELOAD_SECS` and `test_credential_rotation_while_running`
+//! uses both `SMA_CREDENTIALS_RELOAD_SECS` and `SMA_DISABLE_IDENTITY_CACHE`.
+//! These env-var overrides are only active in debug builds of the agent binary.
+//! These tests must be run against a debug build (`cargo build`, not
+//! `cargo build --release`).
+
+mod common;
+
+use aws_credential_types::provider::ProvideCredentials;
+use common::*;
+use std::io::Write;
+use tempfile::NamedTempFile;
+
+/// Helper to write AWS credentials from the environment to a temp file.
+/// Relies on the same credentials the existing integration tests use.
+async fn write_real_credentials(file: &mut NamedTempFile) {
+    let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+    let creds = config
+        .credentials_provider()
+        .expect("No credentials provider")
+        .provide_credentials()
+        .await
+        .expect("Failed to resolve credentials");
+
+    let mut content = format!(
+        "[default]\naws_access_key_id={}\naws_secret_access_key={}\n",
+        creds.access_key_id(),
+        creds.secret_access_key()
+    );
+    if let Some(token) = creds.session_token() {
+        content.push_str(&format!("aws_session_token={}\n", token));
+    }
+    file.write_all(content.as_bytes()).unwrap();
+    file.flush().unwrap();
+}
+
+/// Valid credentials via explicit path: agent starts and can fetch a secret.
+#[tokio::test]
+async fn test_valid_credentials_explicit_path() {
+    let secrets = TestSecrets::setup_basic().await;
+    let secret_name = secrets.secret_name(SecretType::Basic);
+
+    let mut creds_file = NamedTempFile::new().unwrap();
+    write_real_credentials(&mut creds_file).await;
+
+    let agent =
+        AgentProcess::start_with_credentials_file(2785, Some(creds_file.path().to_str().unwrap()))
+            .await;
+
+    let query = AgentQueryBuilder::default()
+        .secret_id(&secret_name)
+        .build()
+        .unwrap();
+    let response = agent.make_request(&query).await;
+    let json: serde_json::Value = serde_json::from_str(&response).unwrap();
+
+    assert_eq!(json["Name"], secret_name);
+    assert!(json["SecretString"].as_str().unwrap().contains("testuser"));
+}
+
+/// Invalid credentials: agent starts but secret fetch returns auth error.
+#[tokio::test]
+async fn test_invalid_credentials_agent_starts() {
+    let mut creds_file = NamedTempFile::new().unwrap();
+    writeln!(
+        creds_file,
+        "[default]\naws_access_key_id=AKIAIOSFODNN7EXAMPLE\naws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\naws_session_token=FakeSessionToken"
+    )
+    .unwrap();
+
+    let agent =
+        AgentProcess::start_with_credentials_file(2786, Some(creds_file.path().to_str().unwrap()))
+            .await;
+
+    let query = AgentQueryBuilder::default()
+        .secret_id("any-secret")
+        .build()
+        .unwrap();
+    let response = agent.make_request_raw(&query).await;
+
+    // Agent started (didn't crash), but request fails with auth error
+    assert_ne!(response.status(), 200);
+    let body = response.text().await.unwrap();
+    assert!(!body.is_empty());
+}
+
+/// Malformed credentials file: agent starts, request returns InternalFailure.
+#[tokio::test]
+async fn test_malformed_credentials_file() {
+    let mut creds_file = NamedTempFile::new().unwrap();
+    writeln!(creds_file, "this is not a credentials file").unwrap();
+
+    let agent =
+        AgentProcess::start_with_credentials_file(2787, Some(creds_file.path().to_str().unwrap()))
+            .await;
+
+    let query = AgentQueryBuilder::default()
+        .secret_id("any-secret")
+        .build()
+        .unwrap();
+    let response = agent.make_request_raw(&query).await;
+
+    assert_ne!(response.status(), 200);
+    let body = response.text().await.unwrap();
+    assert!(body.contains("InternalFailure"));
+}
+
+/// Empty credentials file: agent starts, request returns InternalFailure.
+#[tokio::test]
+async fn test_empty_credentials_file() {
+    let creds_file = NamedTempFile::new().unwrap();
+
+    let agent =
+        AgentProcess::start_with_credentials_file(2788, Some(creds_file.path().to_str().unwrap()))
+            .await;
+
+    let query = AgentQueryBuilder::default()
+        .secret_id("any-secret")
+        .build()
+        .unwrap();
+    let response = agent.make_request_raw(&query).await;
+
+    assert_ne!(response.status(), 200);
+    let body = response.text().await.unwrap();
+    assert!(body.contains("InternalFailure"));
+}
+
+/// Missing path: agent starts, request returns InternalFailure.
+#[tokio::test]
+async fn test_missing_credentials_path() {
+    let agent =
+        AgentProcess::start_with_credentials_file(2789, Some("/tmp/nonexistent_creds_file")).await;
+
+    let query = AgentQueryBuilder::default()
+        .secret_id("any-secret")
+        .build()
+        .unwrap();
+    let response = agent.make_request_raw(&query).await;
+
+    assert_ne!(response.status(), 200);
+    let body = response.text().await.unwrap();
+    assert!(body.contains("InternalFailure"));
+}
+
+/// Self-healing: agent starts with missing credentials, valid creds are written later,
+/// agent picks them up on the next reload cycle.
+#[tokio::test]
+async fn test_self_healing_credentials_appear_after_startup() {
+    let secrets = TestSecrets::setup_basic().await;
+    let secret_name = secrets.secret_name(SecretType::Basic);
+
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let creds_path = tmp_dir.path().join("credentials");
+
+    // Start agent with a 5-second reload delay
+    let agent = AgentProcess::start_with_credentials_file_and_env(
+        2790,
+        Some(creds_path.to_str().unwrap()),
+        &[("SMA_CREDENTIALS_RELOAD_SECS", "5")],
+    )
+    .await;
+
+    // First request should fail — no credentials yet
+    let query = AgentQueryBuilder::default()
+        .secret_id(&secret_name)
+        .build()
+        .unwrap();
+    let response = agent.make_request_raw(&query).await;
+    assert_ne!(response.status(), 200);
+
+    // Write valid credentials to the file
+    let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+    let creds = config
+        .credentials_provider()
+        .expect("No credentials provider")
+        .provide_credentials()
+        .await
+        .expect("Failed to resolve credentials");
+
+    let mut content = format!(
+        "[default]\naws_access_key_id={}\naws_secret_access_key={}\n",
+        creds.access_key_id(),
+        creds.secret_access_key()
+    );
+    if let Some(token) = creds.session_token() {
+        content.push_str(&format!("aws_session_token={}\n", token));
+    }
+    std::fs::write(&creds_path, content).unwrap();
+
+    // Poll until the agent picks up the new credentials or timeout
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(20);
+    loop {
+        let resp = agent.make_request_raw(&query).await;
+        if resp.status() == 200 {
+            let body = resp.text().await.unwrap();
+            let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+            assert_eq!(json["Name"], secret_name);
+            assert!(json["SecretString"].as_str().unwrap().contains("testuser"));
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "Timed out waiting for credentials reload"
+        );
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    }
+}
+
+/// Credential rotation: agent starts with valid credentials, credentials are invalidated,
+/// agent fails, then valid credentials are restored and agent recovers.
+/// This proves the agent is actively re-reading the file on each reload cycle.
+/// Uses SMA_DISABLE_IDENTITY_CACHE to bypass the SDK's internal credential cache,
+/// and refreshNow=true to bypass the secret value cache.
+///
+/// Note: A valid→valid→valid happy path test is not feasible because the test
+/// environment only has one set of credentials (from the CI role). Rewriting the
+/// same credentials to the file changes the mtime (triggering a reload) but the
+/// credential values are identical, making it impossible to observe that the agent
+/// actually swapped credentials. The valid→invalid→valid approach definitively
+/// proves the reload by showing the agent fails with invalid credentials (proving
+/// it stopped using the old cached ones) and recovers when valid credentials are
+/// restored.
+#[tokio::test]
+async fn test_credential_rotation_while_running() {
+    let secrets = TestSecrets::setup_basic().await;
+    let secret_name = secrets.secret_name(SecretType::Basic);
+
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let creds_path = tmp_dir.path().join("credentials");
+
+    // Write initial valid credentials
+    let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+    let creds = config
+        .credentials_provider()
+        .expect("No credentials provider")
+        .provide_credentials()
+        .await
+        .expect("Failed to resolve credentials");
+
+    let mut valid_content = format!(
+        "[default]\naws_access_key_id={}\naws_secret_access_key={}\n",
+        creds.access_key_id(),
+        creds.secret_access_key()
+    );
+    if let Some(token) = creds.session_token() {
+        valid_content.push_str(&format!("aws_session_token={}\n", token));
+    }
+    std::fs::write(&creds_path, &valid_content).unwrap();
+
+    // Start agent with short reload delay and no identity cache
+    let agent = AgentProcess::start_with_credentials_file_and_env(
+        2792,
+        Some(creds_path.to_str().unwrap()),
+        &[
+            ("SMA_CREDENTIALS_RELOAD_SECS", "3"),
+            ("SMA_DISABLE_IDENTITY_CACHE", "1"),
+        ],
+    )
+    .await;
+
+    // Step 1: Verify agent works with initial valid credentials
+    let query = AgentQueryBuilder::default()
+        .secret_id(&secret_name)
+        .build()
+        .unwrap();
+    let response = agent.make_request(&query).await;
+    let json: serde_json::Value = serde_json::from_str(&response).unwrap();
+    assert_eq!(json["Name"], secret_name);
+
+    // Step 2: Overwrite with invalid credentials
+    std::fs::write(
+        &creds_path,
+        "[default]\naws_access_key_id=AKIAIOSFODNN7EXAMPLE\naws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\naws_session_token=FakeSessionToken\n",
+    )
+    .unwrap();
+
+    // Poll until agent returns errors (proves it picked up invalid creds)
+    // Use refreshNow=true to bypass the secret value cache
+    let refresh_query = AgentQueryBuilder::default()
+        .secret_id(&secret_name)
+        .refresh_now(true)
+        .build()
+        .unwrap();
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(20);
+    loop {
+        let resp = agent.make_request_raw(&refresh_query).await;
+        if resp.status() != 200 {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "Timed out waiting for agent to pick up invalid credentials"
+        );
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+
+    // Step 3: Restore valid credentials
+    std::fs::write(&creds_path, &valid_content).unwrap();
+
+    // Poll until agent recovers
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(20);
+    loop {
+        let resp = agent.make_request_raw(&refresh_query).await;
+        if resp.status() == 200 {
+            let body = resp.text().await.unwrap();
+            let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+            assert_eq!(json["Name"], secret_name);
+            assert!(json["SecretString"].as_str().unwrap().contains("testuser"));
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "Timed out waiting for agent to recover with valid credentials"
+        );
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+}


### PR DESCRIPTION
## Description

### Why is this change being made?

1. Add FileBasedCredentialsProvider that reads AWS credentials from a configurable file path and automatically reloads them when the file changes. This enables the agent to run in environments where credentials are delivered to the filesystem (e.g., IAM Roles Anywhere).


### What is changing?

1. New `credentials_file_path` config parameter
2. Background reload every 5 minutes with mtime-based change detection
3. Graceful startup when credentials file is missing or malformed
4. STS validation automatically skipped for file-based credentials
5. File permission warning on Unix when permissions are broader than 0600
6. Integration tests for self-healing and credential rotation
7. README documentation for the feature


### Related Links
- **Issue #, if available**:

---

## Testing

### How was this tested?

1. `cargo test -p aws_secretsmanager_agent`: 79 unit tests pass, covering valid/invalid/missing/empty credential files, credential reload, permission changes, and failed-reload retry behavior                                     
2. `cd integration-tests && cargo test -- --test-threads=1`: 22 integration tests pass, including 7 new file-based credential tests (valid explicit path, invalid credentials, malformed file, empty file, missing path, self-healing, credential rotation)
3. Manual end-to-end testing with real file-based credentials on a Linux host, verifying agent startup, secret retrieval, and credential reload

### When testing locally, provide testing artifact(s):

1. `cargo test -p aws_secretsmanager_agent`: 79 passed, 0 failed
2. `cd integration-tests && cargo test -- --test-threads=1`: 22 passed, 0 failed

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [x] Build and Unit tests are passing
  *If not, why:*
- [x] Unit test coverage check is passing
  *If not, why:*
- [x] Integration tests pass locally
  *If not, why:*
- [x] I have updated integration tests (if needed)
  *If not, why:*
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [x] I have updated README/documentation (if needed)
  *If not, why:*
- [x] I have clearly called out breaking changes (if any)
  *If not, why:* No breaking changes, fully backward compatible. When credentials_file_path is not set, the agent uses the default SDK credential chain as before.

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
