### PR TITLE
Add pre-fetching support for warming the secret cache at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-fips-sys",
  "aws-lc-sys",
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -590,6 +590,7 @@ dependencies = [
  "log",
  "log4rs",
  "pretty_env_logger",
+ "rand 0.10.1",
  "regex",
  "serde",
  "serde_derive",
@@ -612,7 +613,7 @@ dependencies = [
  "http 0.2.12",
  "linked-hash-map",
  "log",
- "rand",
+ "rand 0.9.4",
  "rustls 0.23.40",
  "serde",
  "serde_json",
@@ -791,6 +792,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -1430,6 +1442,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1515,9 +1533,23 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1604,6 +1636,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
@@ -1616,6 +1657,12 @@ checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
  "hashbrown 0.14.5",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1937,6 +1984,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2072,6 +2125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2141,7 +2200,7 @@ dependencies = [
  "log-mdc",
  "mock_instant",
  "parking_lot",
- "rand",
+ "rand 0.9.4",
  "serde",
  "serde-value",
  "serde_json",
@@ -2545,7 +2604,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls 0.23.40",
@@ -2587,6 +2646,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2594,6 +2659,17 @@ checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2623,6 +2699,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -3807,7 +3889,16 @@ version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -3863,6 +3954,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "semver",
 ]
 
 [[package]]
@@ -4151,9 +4276,97 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.14.0",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -4229,9 +4442,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ To download the source code, see [https://github\.com/aws/aws\-secretsmanager\-a
     - [Example - Secrets Manager Agent GET request with refreshNow parameter](#example---secrets-manager-agent-get-request-with-refreshnow-parameter)
       - [\[ curl \]](#-curl--1)
       - [\[ Python \]](#-python--1)
+  - [Role chaining (cross-account access)](#role-chaining-cross-account-access)
+  - [Pre-fetching](#pre-fetching)
   - [Configure the Secrets Manager Agent](#configure-the-secrets-manager-agent)
   - [Optional features](#optional-features)
   - [Logging](#logging)
@@ -37,6 +39,7 @@ To download the source code, see [https://github\.com/aws/aws\-secretsmanager\-a
   - [Running Integration Tests Locally](#running-integration-tests-locally)
     - [Prerequisites](#prerequisites)
     - [Required AWS Permissions](#required-aws-permissions)
+    - [Required IAM Roles (for role chaining tests)](#required-iam-roles-for-role-chaining-tests)
     - [Running Tests](#running-tests)
       - [Option 1: Using the test script](#option-1-using-the-test-script)
       - [Option 2: Manual execution](#option-2-manual-execution)
@@ -302,7 +305,7 @@ The following instructions show how to get a secret named *MyTest* by using the 
 
 ## Step 3: Retrieve secrets with the Secrets Manager Agent<a name="secrets-manager-agent-call"></a>
 
-To use the agent, you call the local Secrets Manager Agent endpoint and include the name or ARN of the secret as a query parameter\. By default, the Secrets Manager Agent retrieves the `AWSCURRENT` version of the secret\. To retrieve a different version, you can set `versionStage` or `versionId`\.
+To use the agent, you call the local Secrets Manager Agent endpoint and include the name or ARN of the secret as a query parameter\. By default, the Secrets Manager Agent retrieves the `AWSCURRENT` version of the secret\. To retrieve a different version, you can set `versionStage` or `versionId`\. To retrieve a secret using a different IAM role, you can set `roleArn`\. For more information, see [Role chaining \(cross\-account access\)](#role-chaining-cross-account-access)\.
 
 To help protect the Secrets Manager Agent, you must include a SSRF token header as part of each request: `X-Aws-Parameters-Secrets-Token`\. The Secrets Manager Agent denies requests that don't have this header or that have an invalid SSRF token\. You can customize the SSRF header name in the [Configuration file](#secrets-manager-agent-config)\.
 
@@ -336,7 +339,6 @@ The following Python example shows how to get a secret from the Secrets Manager 
 
 ```python
 import requests
-import json
 
 # Function that fetches the secret from Secrets Manager Agent for the provided secret id. 
 def get_secret():
@@ -425,7 +427,6 @@ The following Python example shows how to get a secret from the Secrets Manager 
 
 ```python
 import requests
-import json
 
 # Function that fetches the secret from Secrets Manager Agent for the provided secret id. 
 def get_secret():
@@ -458,6 +459,156 @@ def get_secret():
 ```
 ------
 
+## Role chaining \(cross\-account access\)<a name="role-chaining-cross-account-access"></a>
+
+The Secrets Manager Agent supports retrieving secrets using IAM role assumption \(role chaining\)\. This allows you to access secrets in other AWS accounts or with different IAM permissions without running separate agent instances\.
+
+To retrieve a secret using a different IAM role, include the `roleArn` query parameter in your request\. The Secrets Manager Agent uses STS `AssumeRole` to obtain temporary credentials for the specified role and then retrieves the secret with those credentials\.
+
+The Secrets Manager Agent creates and caches a separate caching client for each unique role ARN\. Role clients are created lazily on first request and reused for subsequent requests with the same role ARN\. Each role client maintains its own independent cache, so the same secret fetched with different roles will have separate cache entries\.
+
+**Required permissions: **
++ `sts:AssumeRole` on the target role ARN
++ The target role must have `secretsmanager:GetSecretValue` and `secretsmanager:DescribeSecret` permissions
+
+**Error responses: **
++ `400` – If the `roleArn` format is invalid or the maximum number of assumed roles has been reached\.
++ `403` – If the STS `AssumeRole` call fails \(for example, the trust policy does not allow the agent's identity to assume the role\)\.
+
+You can configure the maximum number of simultaneous assumed roles with the `max_roles` option in the [Configuration file](#secrets-manager-agent-config)\. The default is 20\.
+
+**Note:** Assumed roles are not evicted from the agent's role cache\. Once the maximum number of roles has been reached, requests with new role ARNs will be rejected with a `400` error until the agent is restarted\.
+
+------
+#### [ curl ]
+
+The following curl example shows how to retrieve a secret using a different IAM role\.
+
+```sh
+curl -v -H \
+    "X-Aws-Parameters-Secrets-Token: $(</var/run/awssmatoken)" \
+    'http://localhost:2773/secretsmanager/get?secretId=<YOUR_SECRET_ID>&roleArn=arn:aws:iam::<ACCOUNT_ID>:role/<ROLE_NAME>'; \
+    echo
+```
+
+------
+#### [ Python ]
+
+The following Python example shows how to retrieve a secret using a different IAM role\.
+
+```python
+import requests
+
+def get_secret_cross_account():
+    role_arn = "arn:aws:iam::<ACCOUNT_ID>:role/<ROLE_NAME>"
+    url = f"http://localhost:2773/secretsmanager/get?secretId=<YOUR_SECRET_ID>&roleArn={role_arn}"
+
+    with open('/var/run/awssmatoken') as fp:
+        token = fp.read()
+
+    headers = {
+        "X-Aws-Parameters-Secrets-Token": token.strip()
+    }
+
+    try:
+        response = requests.get(url, headers=headers)
+
+        if response.status_code == 200:
+            return response.text
+        else:
+            raise Exception(f"Status code {response.status_code} - {response.text}")
+
+    except Exception as e:
+        raise Exception(f"Error: {e}")
+```
+
+------
+
+## Pre\-fetching<a name="pre-fetching"></a>
+
+The Secrets Manager Agent supports pre\-fetching secrets into the cache at startup\. This allows your application to read secrets from the cache immediately without waiting for the first request to trigger a cache miss and network call\.
+
+To enable pre\-fetching, add a `[prefetch]` section to your [Configuration file](#secrets-manager-agent-config)\. You can specify secrets to pre\-fetch in two ways:
+
++ **Explicit secrets** – List specific secret IDs or ARNs using `[[prefetch.secrets]]` entries\.
++ **Tag\-based discovery** – Discover secrets by tag key using `[[prefetch.filter_tags]]` entries\. The agent calls `BatchGetSecretValue` with tag key filters to find and cache all secrets that have the specified tag key, regardless of the tag's value\.
+
+You can use both methods together\. Each entry optionally accepts a `role_arn` field for cross\-account pre\-fetching via [role chaining](#role-chaining-cross-account-access)\.
+
+**Required permissions: **
++ `secretsmanager:BatchGetSecretValue` – Required for all pre\-fetching operations\.
++ `secretsmanager:ListSecrets` – Required when using tag\-based discovery \(`filter_tags`\)\.
+
+**Pre\-fetch configuration options: **
++ **cache\_buffer\_ratio** – The maximum fraction of the cache to fill per caching client during pre\-fetch, in the range 0\.1 to 1\.0\. The default is 0\.8\.
++ **max\_jitter\_seconds** – The maximum random delay in seconds before starting the pre\-fetch task, in the range 0 to 10\. The default is 0 \(no jitter\)\. Use this to prevent fleet\-wide synchronized API calls\.
+
+### Example \- Pre\-fetch with explicit secrets
+
+```toml
+[[prefetch.secrets]]
+secret_id = "arn:aws:secretsmanager:us-west-2:123456789012:secret:MySecret-AbCdEf"
+
+[[prefetch.secrets]]
+secret_id = "cross-account-secret"
+role_arn = "arn:aws:iam::987654321098:role/SecretAccessRole"
+```
+
+### Example \- Pre\-fetch with explicit secrets \(inline syntax\)
+
+```toml
+[prefetch]
+max_jitter_seconds = 5
+cache_buffer_ratio = 0.9
+secrets = [
+  { secret_id = "arn:aws:secretsmanager:us-west-2:123456789012:secret:MySecret-AbCdEf" },
+  { secret_id = "cross-account-secret", role_arn = "arn:aws:iam::987654321098:role/SecretAccessRole" },
+]
+filter_tags = [
+  { key = "Environment" },
+  { key = "Team", role_arn = "arn:aws:iam::987654321098:role/SecretAccessRole" },
+]
+```
+
+### Example \- Pre\-fetch with tag\-based discovery
+
+```toml
+[[prefetch.filter_tags]]
+key = "Environment"
+
+[[prefetch.filter_tags]]
+key = "Team"
+role_arn = "arn:aws:iam::987654321098:role/SecretAccessRole"
+```
+
+### Example \- Full configuration with pre\-fetching
+
+```toml
+log_level = "info"
+http_port = 2773
+ttl_seconds = 300
+region = "us-east-1"
+max_roles = 5
+
+[prefetch]
+cache_buffer_ratio = 0.6
+max_jitter_seconds = 5
+
+[[prefetch.secrets]]
+secret_id = "arn:aws:secretsmanager:us-west-2:123456789012:secret:MySecret-AbCdEf"
+
+[[prefetch.secrets]]
+secret_id = "arn:aws:secretsmanager:us-east-1:987654321098:secret:CrossAccount-AbCdEf"
+role_arn = "arn:aws:iam::987654321098:role/SecretAccessRole"
+
+[[prefetch.filter_tags]]
+key = "Environment"
+
+[[prefetch.filter_tags]]
+key = "Team"
+role_arn = "arn:aws:iam::987654321098:role/TagRole"
+```
+
 ## Configure the Secrets Manager Agent<a name="secrets-manager-agent-config"></a>
 
 To change the configuration of the Secrets Manager Agent, create a [TOML](https://toml.io/en/) config file, and then call `./aws_secretsmanager_agent --config config.toml`\.
@@ -473,6 +624,9 @@ The following list shows the options you can configure for the Secrets Manager A
 + **ssrf\_env\_variables** – A list of environment variable names the Secrets Manager Agent checks in sequential order for the SSRF token\. The environment variable can contain the token or a reference to the token file as in: `AWS_TOKEN=file:///var/run/awssmatoken`\. The default is "AWS\_TOKEN, AWS\_SESSION\_TOKEN, AWS\_CONTAINER\_AUTHORIZATION\_TOKEN\".
 + **path\_prefix** – The URI prefix used to determine if the request is a path based request\. The default is "/v1/"\.
 + **max\_conn** – The maximum number of connections from HTTP clients that the Secrets Manager Agent allows, in the range 1 to 1000\. The default is 800\.
++ **max\_roles** – The maximum number of IAM roles the Secrets Manager Agent can assume simultaneously for cross\-account access, in the range 1 to 20\. The default is 20\. For more information, see [Role chaining \(cross\-account access\)](#role-chaining-cross-account-access)\.
+
+
 ## Optional features<a name="secrets-manager-agent-features"></a>
 
 The Secrets Manager Agent can be built with optional features by passing the `--features` flag to `cargo build`. The available features are:
@@ -515,6 +669,19 @@ Your AWS credentials must have the following permissions:
 - `secretsmanager:UpdateSecretVersionStage`
 - `secretsmanager:PutSecretValue`
 - `secretsmanager:DeleteSecret`
+- `secretsmanager:BatchGetSecretValue`
+- `secretsmanager:ListSecrets`
+- `sts:AssumeRole`
+
+### Required IAM Roles (for role chaining tests)
+
+The role chaining integration tests require two IAM roles in the same account:
+
+1. **`secrets-manager-agent`** — Must be assumable by the test runner's identity and have `secretsmanager:GetSecretValue` and `secretsmanager:DescribeSecret` permissions.
+
+2. **`secrets-manager-agent-no-access`** — Must be assumable by the test runner's identity but have *no* Secrets Manager permissions. Used to verify access-denied behavior.
+
+Both roles must have a trust policy that allows the identity running the tests to call `sts:AssumeRole`. The account ID is discovered automatically via `sts:GetCallerIdentity`.
 
 ### Running Tests
 
@@ -551,3 +718,5 @@ The integration tests are organized into the following modules:
 - **`security.rs`** - Tests security features including SSRF token validation and X-Forwarded-For header rejection
 - **`version_management.rs`** - Tests secret version transitions and rotation scenarios
 - **`configuration.rs`** - Tests configuration parameters including health checks and path-based requests
+- **`role_chaining.rs`** - Tests cross\-account secret retrieval via IAM role assumption, including invalid role ARN handling, access denied scenarios, refreshNow with role chaining, and separate per\-role cache isolation
+- **`prefetch.rs`** - Tests pre\-fetching secrets into the cache at startup, including explicit secrets, tag\-based discovery, inline TOML syntax, cross\-account pre\-fetching via role chaining, and resilience to nonexistent secrets

--- a/aws_secretsmanager_agent/Cargo.toml
+++ b/aws_secretsmanager_agent/Cargo.toml
@@ -33,11 +33,13 @@ log4rs = { version = "1.2.0", features = ["gzip"] }
 url = "2"
 regex = "1"
 aws_secretsmanager_caching = { version = "2.0.0", path = "../aws_secretsmanager_caching" }
+rand = "0.10"
 
 # For unit tests
 [dev-dependencies]
 hyper = { version = "1", features = ["http1", "server", "client"] }
 aws-smithy-runtime = { version = "1", features = ["test-util"] }
+aws_secretsmanager_caching = { version = "2.0.0", path = "../aws_secretsmanager_caching", features = ["test-util"] }
 tokio = { version = "1", features = ["test-util", "rt-multi-thread", "net", "macros"] }
 http = "0.2.9"
 aws-smithy-types = "1"

--- a/aws_secretsmanager_agent/src/cache_manager.rs
+++ b/aws_secretsmanager_agent/src/cache_manager.rs
@@ -180,7 +180,7 @@ impl CacheManager {
     ///
     /// * `HttpError(400, ...)` - If the `max_roles` limit has been reached.
     /// * `HttpError(403, ...)` - If role client creation fails (e.g. STS AssumeRole denied).
-    async fn get_client(
+    pub(crate) async fn get_client(
         &self,
         role_arn: Option<&str>,
     ) -> Result<Arc<SecretsManagerCachingClient>, HttpError> {
@@ -437,8 +437,68 @@ pub mod tests {
             .unwrap()
             .contains(APPNAME)); // validate user-agent
 
+        let target = parts.headers["x-amz-target"].to_str().unwrap();
         let req_map: serde_json::Map<String, Value> =
             serde_json::from_slice(body.bytes().unwrap()).unwrap();
+
+        // Handle BatchGetSecretValue requests
+        if target == "secretsmanager.BatchGetSecretValue" {
+            let secret_ids = req_map
+                .get("SecretIdList")
+                .and_then(|v| v.as_array())
+                .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>())
+                .unwrap_or_default();
+            let has_filters = req_map.get("Filters").is_some();
+
+            if secret_ids.iter().any(|s| s.starts_with("BATCHAPIERROR")) {
+                return (
+                    400,
+                    r#"{"__type":"InvalidParameterException","message":"invalid"}"#.to_string(),
+                );
+            }
+
+            if secret_ids.iter().any(|s| s.starts_with("NOTFOUND")) {
+                let valid = secret_ids
+                    .iter()
+                    .find(|s| !s.starts_with("NOTFOUND"))
+                    .unwrap_or(&"Valid");
+                let err = secret_ids
+                    .iter()
+                    .find(|s| s.starts_with("NOTFOUND"))
+                    .unwrap_or(&"NOTFOUND");
+                return (
+                    200,
+                    format!(
+                        r#"{{"SecretValues":[{{"ARN":"{}","Name":"{}","VersionId":"{}","SecretString":"{}","VersionStages":["{}"],"CreatedDate":1569534789.046}}],"Errors":[{{"SecretId":"{}","ErrorCode":"ResourceNotFoundException","Message":"not found"}}]}}"#,
+                        FAKE_ARN.replace("{{name}}", valid),
+                        valid,
+                        DEFAULT_VERSION,
+                        DEFAULT_SECRET_STRING,
+                        DEFAULT_LABEL,
+                        err
+                    ),
+                );
+            }
+
+            // For filter-based requests or secret ID list requests, return a single secret
+            let name = if has_filters {
+                "TaggedSecret"
+            } else {
+                secret_ids.first().unwrap_or(&"MyTest")
+            };
+            return (
+                200,
+                format!(
+                    r#"{{"SecretValues":[{{"ARN":"{}","Name":"{}","VersionId":"{}","SecretString":"{}","VersionStages":["{}"],"CreatedDate":1569534789.046}}],"Errors":[]}}"#,
+                    FAKE_ARN.replace("{{name}}", name),
+                    name,
+                    DEFAULT_VERSION,
+                    DEFAULT_SECRET_STRING,
+                    DEFAULT_LABEL
+                ),
+            );
+        }
+
         let version = req_map
             .get("VersionId")
             .map_or(DEFAULT_VERSION, |x| x.as_str().unwrap());
@@ -456,7 +516,7 @@ pub mod tests {
             _ => DEFAULT_SECRET_STRING.to_string(),
         };
 
-        let (code, template) = match parts.headers["x-amz-target"].to_str().unwrap() {
+        let (code, template) = match target {
             "secretsmanager.GetSecretValue" if name.starts_with("KMSACCESSDENIED") => {
                 (400, KMS_ACCESS_DENIED_BODY)
             }

--- a/aws_secretsmanager_agent/src/config.rs
+++ b/aws_secretsmanager_agent/src/config.rs
@@ -1,6 +1,7 @@
 use crate::constants::EMPTY_ENV_LIST_MSG;
 use crate::constants::{BAD_MAX_CONN_MSG, BAD_MAX_ROLES_MSG, BAD_PREFIX_MSG, EMPTY_SSRF_LIST_MSG};
 use crate::constants::{DEFAULT_MAX_CONNECTIONS, DEFAULT_MAX_ROLES, GENERIC_CONFIG_ERR_MSG};
+use crate::constants::{INVALID_CACHE_BUFFER_RATIO_MSG, INVALID_MAX_JITTER_MSG};
 use crate::constants::{INVALID_CACHE_SIZE_ERR_MSG, INVALID_HTTP_PORT_ERR_MSG};
 use crate::constants::{INVALID_LOG_LEVEL_ERR_MSG, INVALID_TTL_SECONDS_ERR_MSG};
 use config::Config as ConfigLib;
@@ -27,6 +28,67 @@ const DEFAULT_IGNORE_TRANSIENT_ERRORS: bool = true;
 const DEFAULT_STS_CHECK: bool = true;
 
 const DEFAULT_REGION: Option<String> = None;
+const DEFAULT_CACHE_BUFFER_RATIO: f32 = 0.8;
+
+/// A single secret to pre-fetch.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct SecretPrefetchConfig {
+    pub secret_id: String,
+    pub role_arn: Option<String>,
+}
+
+/// A single tag filter entry for tag-based pre-fetching.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct TagFilter {
+    pub key: String,
+    pub role_arn: Option<String>,
+}
+
+/// Top-level prefetch configuration.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct PrefetchConfig {
+    /// Maximum fraction of cache to fill per caching client (0.1 - 1.0).
+    #[serde(default = "default_cache_buffer_ratio")]
+    pub cache_buffer_ratio: f32,
+
+    /// Maximum random jitter in seconds before starting prefetch (0 - 10).
+    /// Helps prevent fleet-wide synchronized API calls. Default is 0 (no jitter).
+    #[serde(default)]
+    pub max_jitter_seconds: u64,
+
+    /// Tag-based filtering: each entry is a { key, role_arn? } tuple.
+    #[serde(default)]
+    pub filter_tags: Vec<TagFilter>,
+
+    /// Explicit secrets to pre-fetch.
+    #[serde(default)]
+    pub secrets: Vec<SecretPrefetchConfig>,
+}
+
+fn default_cache_buffer_ratio() -> f32 {
+    DEFAULT_CACHE_BUFFER_RATIO
+}
+
+impl Default for PrefetchConfig {
+    fn default() -> Self {
+        PrefetchConfig {
+            cache_buffer_ratio: DEFAULT_CACHE_BUFFER_RATIO,
+            max_jitter_seconds: 0,
+            filter_tags: Vec::new(),
+            secrets: Vec::new(),
+        }
+    }
+}
+
+impl PrefetchConfig {
+    /// Returns true if there are any secrets or tag filters configured.
+    pub fn is_enabled(&self) -> bool {
+        !self.filter_tags.is_empty() || !self.secrets.is_empty()
+    }
+}
 
 /// Private struct used to deserialize configurations from the file.
 #[doc(hidden)]
@@ -46,6 +108,8 @@ struct ConfigFile {
     region: Option<String>,
     ignore_transient_errors: bool,
     validate_credentials: bool,
+    #[serde(default)]
+    prefetch: Option<PrefetchConfig>,
 }
 
 /// The log levels supported by the daemon.
@@ -116,6 +180,9 @@ pub struct Config {
 
     /// Whether the agent should validate AWS credentials at startup
     validate_credentials: bool,
+
+    /// Pre-fetch configuration for warming the cache at startup
+    prefetch: PrefetchConfig,
 }
 
 /// The default configuration options.
@@ -292,6 +359,15 @@ impl Config {
         self.validate_credentials
     }
 
+    /// The pre-fetch configuration for warming the cache at startup.
+    ///
+    /// # Returns
+    ///
+    /// * `PrefetchConfig` - The prefetch configuration. Defaults to disabled (empty).
+    pub fn prefetch(&self) -> &PrefetchConfig {
+        &self.prefetch
+    }
+
     /// Private helper that fills in the Config instance from the specified
     /// config overrides (or defaults).
     ///
@@ -305,6 +381,14 @@ impl Config {
     /// * `Err(Error)` - An error message with the configuration error.
     #[doc(hidden)]
     fn build(config_file: ConfigFile) -> Result<Config, Box<dyn std::error::Error>> {
+        let prefetch = config_file.prefetch.unwrap_or_default();
+        if !(0.1..=1.0).contains(&prefetch.cache_buffer_ratio) {
+            Err(INVALID_CACHE_BUFFER_RATIO_MSG)?;
+        }
+        if prefetch.max_jitter_seconds > 10 {
+            Err(INVALID_MAX_JITTER_MSG)?;
+        }
+
         let config = Config {
             // Configurations that are allowed to be overridden.
             log_level: LogLevel::from_str(config_file.log_level.as_str())?,
@@ -348,6 +432,7 @@ impl Config {
             region: config_file.region,
             ignore_transient_errors: config_file.ignore_transient_errors,
             validate_credentials: config_file.validate_credentials,
+            prefetch,
         };
 
         // Additional validations.
@@ -434,6 +519,7 @@ mod tests {
             region: None,
             ignore_transient_errors: DEFAULT_IGNORE_TRANSIENT_ERRORS,
             validate_credentials: DEFAULT_STS_CHECK,
+            prefetch: None,
         }
     }
 
@@ -462,6 +548,8 @@ mod tests {
         assert_eq!(config.clone().region(), None);
         assert!(config.ignore_transient_errors());
         assert!(config.validate_credentials());
+        assert!(!config.prefetch().is_enabled());
+        assert_eq!(config.prefetch().cache_buffer_ratio, 0.8);
     }
 
     /// Tests the config overrides are applied correctly from the provided config file.
@@ -694,5 +782,298 @@ mod tests {
             "tests/resources/configs/config_file_with_invalid_contents.toml",
         ))
         .unwrap();
+    }
+
+    /// Tests TOML parsing of a valid prefetch config with explicit secrets.
+    #[test]
+    fn test_prefetch_toml_with_secrets() {
+        let config = Config::new(Some(
+            "tests/resources/configs/config_file_prefetch_secrets.toml",
+        ))
+        .unwrap();
+        assert!(config.prefetch().is_enabled());
+        assert_eq!(config.prefetch().secrets.len(), 2);
+        assert_eq!(
+            config.prefetch().secrets[0].secret_id,
+            "arn:aws:secretsmanager:us-west-2:123456789012:secret:MySecret-AbCdEf"
+        );
+        assert!(config.prefetch().secrets[0].role_arn.is_none());
+        assert_eq!(
+            config.prefetch().secrets[1].role_arn.as_deref(),
+            Some("arn:aws:iam::987654321098:role/SecretAccessRole")
+        );
+    }
+
+    /// Tests TOML parsing of a valid prefetch config with tag filters.
+    #[test]
+    fn test_prefetch_toml_with_tags() {
+        let config = Config::new(Some(
+            "tests/resources/configs/config_file_prefetch_tags.toml",
+        ))
+        .unwrap();
+        assert!(config.prefetch().is_enabled());
+        assert_eq!(config.prefetch().filter_tags.len(), 2);
+        assert_eq!(config.prefetch().filter_tags[0].key, "Environment");
+        assert!(config.prefetch().filter_tags[0].role_arn.is_none());
+        assert_eq!(config.prefetch().filter_tags[1].key, "Team");
+        assert_eq!(
+            config.prefetch().filter_tags[1].role_arn.as_deref(),
+            Some("arn:aws:iam::987654321098:role/SecretAccessRole")
+        );
+    }
+
+    /// Tests TOML parsing of a valid prefetch config with both secrets and tags.
+    #[test]
+    fn test_prefetch_toml_with_both() {
+        let config = Config::new(Some(
+            "tests/resources/configs/config_file_prefetch_both.toml",
+        ))
+        .unwrap();
+        assert!(config.prefetch().is_enabled());
+        assert_eq!(config.prefetch().secrets.len(), 1);
+        assert_eq!(config.prefetch().filter_tags.len(), 1);
+        assert_eq!(config.prefetch().cache_buffer_ratio, 0.5);
+    }
+
+    /// Tests that an empty prefetch section results in disabled prefetch.
+    #[test]
+    fn test_prefetch_toml_empty_section() {
+        let config = Config::new(Some(
+            "tests/resources/configs/config_file_prefetch_empty.toml",
+        ))
+        .unwrap();
+        assert!(!config.prefetch().is_enabled());
+        assert_eq!(config.prefetch().cache_buffer_ratio, 0.8);
+    }
+
+    /// Tests that no prefetch section results in disabled prefetch.
+    #[test]
+    fn test_prefetch_not_present() {
+        let config = Config::new(Some("tests/resources/configs/config_file_empty.toml")).unwrap();
+        assert!(!config.prefetch().is_enabled());
+    }
+
+    /// Tests valid cache_buffer_ratio values.
+    #[test]
+    fn test_prefetch_cache_buffer_ratio_valid() {
+        for ratio in [0.1, 0.5, 0.8, 1.0] {
+            let config_file = ConfigFile {
+                prefetch: Some(PrefetchConfig {
+                    cache_buffer_ratio: ratio,
+                    ..PrefetchConfig::default()
+                }),
+                ..get_default_config_file()
+            };
+            let config = Config::build(config_file).unwrap();
+            assert_eq!(
+                config.prefetch().cache_buffer_ratio,
+                ratio,
+                "ratio {} should be valid",
+                ratio
+            );
+        }
+    }
+
+    /// Tests invalid cache_buffer_ratio values.
+    #[test]
+    fn test_prefetch_cache_buffer_ratio_invalid() {
+        for ratio in [0.0, 1.1, -0.5, 0.09, 1.01] {
+            let config_file = ConfigFile {
+                prefetch: Some(PrefetchConfig {
+                    cache_buffer_ratio: ratio,
+                    ..PrefetchConfig::default()
+                }),
+                ..get_default_config_file()
+            };
+            match Config::build(config_file) {
+                Ok(_) => panic!("ratio {} should be invalid", ratio),
+                Err(e) => assert_eq!(e.to_string(), INVALID_CACHE_BUFFER_RATIO_MSG),
+            };
+        }
+    }
+
+    /// Tests that invalid cache_buffer_ratio fails Config::build().
+    #[test]
+    fn test_prefetch_invalid_ratio_fails_build() {
+        let config_file = ConfigFile {
+            prefetch: Some(PrefetchConfig {
+                cache_buffer_ratio: 0.0,
+                secrets: vec![SecretPrefetchConfig {
+                    secret_id: "test".to_string(),
+                    role_arn: None,
+                }],
+                filter_tags: vec![],
+                ..PrefetchConfig::default()
+            }),
+            ..get_default_config_file()
+        };
+        match Config::build(config_file) {
+            Ok(_) => panic!("should fail with invalid ratio"),
+            Err(e) => assert_eq!(e.to_string(), INVALID_CACHE_BUFFER_RATIO_MSG),
+        };
+    }
+
+    /// Tests is_enabled returns true with secrets only.
+    #[test]
+    fn test_prefetch_is_enabled_with_secrets() {
+        let prefetch = PrefetchConfig {
+            secrets: vec![SecretPrefetchConfig {
+                secret_id: "test".to_string(),
+                role_arn: None,
+            }],
+            ..PrefetchConfig::default()
+        };
+        assert!(prefetch.is_enabled());
+    }
+
+    /// Tests is_enabled returns true with tags only.
+    #[test]
+    fn test_prefetch_is_enabled_with_tags() {
+        let prefetch = PrefetchConfig {
+            filter_tags: vec![TagFilter {
+                key: "Environment".to_string(),
+                role_arn: None,
+            }],
+            ..PrefetchConfig::default()
+        };
+        assert!(prefetch.is_enabled());
+    }
+
+    /// Tests is_enabled returns false when empty.
+    #[test]
+    fn test_prefetch_is_enabled_empty() {
+        let prefetch = PrefetchConfig::default();
+        assert!(!prefetch.is_enabled());
+    }
+
+    /// Tests that max_jitter_seconds defaults to 0.
+    #[test]
+    fn test_prefetch_max_jitter_default() {
+        let config = Config::new(Some(
+            "tests/resources/configs/config_file_prefetch_empty.toml",
+        ))
+        .unwrap();
+        assert_eq!(config.prefetch().max_jitter_seconds, 0);
+    }
+
+    /// Tests that max_jitter_seconds is parsed from TOML.
+    #[test]
+    fn test_prefetch_max_jitter_from_toml() {
+        let config = Config::new(Some(
+            "tests/resources/configs/config_file_prefetch_jitter.toml",
+        ))
+        .unwrap();
+        assert_eq!(config.prefetch().max_jitter_seconds, 5);
+    }
+
+    /// Tests that max_jitter_seconds boundary value 10 is valid.
+    #[test]
+    fn test_prefetch_max_jitter_valid_boundary() {
+        let config_file = ConfigFile {
+            prefetch: Some(PrefetchConfig {
+                max_jitter_seconds: 10,
+                ..PrefetchConfig::default()
+            }),
+            ..get_default_config_file()
+        };
+        let config = Config::build(config_file).unwrap();
+        assert_eq!(config.prefetch().max_jitter_seconds, 10);
+    }
+
+    /// Tests that max_jitter_seconds > 10 is rejected.
+    #[test]
+    fn test_prefetch_max_jitter_invalid() {
+        let config_file = ConfigFile {
+            prefetch: Some(PrefetchConfig {
+                max_jitter_seconds: 11,
+                ..PrefetchConfig::default()
+            }),
+            ..get_default_config_file()
+        };
+        match Config::build(config_file) {
+            Ok(_) => panic!("max_jitter_seconds 11 should be invalid"),
+            Err(e) => assert_eq!(e.to_string(), INVALID_MAX_JITTER_MSG),
+        };
+    }
+
+    /// Tests that inline array syntax for secrets works identically to array-of-tables.
+    #[test]
+    fn test_prefetch_inline_secrets_syntax() {
+        let config = Config::new(Some(
+            "tests/resources/configs/config_file_prefetch_inline.toml",
+        ))
+        .unwrap();
+        assert!(config.prefetch().is_enabled());
+        assert_eq!(config.prefetch().secrets.len(), 2);
+        assert_eq!(
+            config.prefetch().secrets[0].secret_id,
+            "arn:aws:secretsmanager:us-west-2:123456789012:secret:MySecret-AbCdEf"
+        );
+        assert!(config.prefetch().secrets[0].role_arn.is_none());
+        assert_eq!(
+            config.prefetch().secrets[1].secret_id,
+            "cross-account-secret"
+        );
+        assert_eq!(
+            config.prefetch().secrets[1].role_arn.as_deref(),
+            Some("arn:aws:iam::987654321098:role/SecretAccessRole")
+        );
+    }
+
+    /// Regression test: full config with all original parameters plus prefetch.
+    /// Ensures adding prefetch doesn't break parsing of existing fields.
+    #[test]
+    fn test_full_config_with_prefetch_no_regression() {
+        let config = Config::new(Some(
+            "tests/resources/configs/config_file_full_with_prefetch.toml",
+        ))
+        .unwrap();
+
+        // Original parameters
+        assert_eq!(config.log_level(), LogLevel::Debug);
+        assert_eq!(config.http_port(), 65535);
+        assert_eq!(config.ttl(), Duration::from_secs(600));
+        assert_eq!(config.cache_size(), NonZeroUsize::new(500).unwrap());
+        assert_eq!(
+            config.ssrf_headers(),
+            vec!["X-Aws-Parameters-Secrets-Token".to_string()]
+        );
+        assert_eq!(config.ssrf_env_variables(), vec!["MY_TOKEN".to_string()]);
+        assert_eq!(config.path_prefix(), "/custom/");
+        assert_eq!(config.max_conn(), 100);
+        assert_eq!(config.max_roles(), 10);
+        assert_eq!(config.region(), Some(&"us-east-1".to_string()));
+        assert!(!config.ignore_transient_errors());
+        assert!(!config.validate_credentials());
+
+        // Prefetch parameters
+        assert!(config.prefetch().is_enabled());
+        assert_eq!(config.prefetch().cache_buffer_ratio, 0.6);
+
+        // Prefetch secrets
+        assert_eq!(config.prefetch().secrets.len(), 2);
+        assert_eq!(
+            config.prefetch().secrets[0].secret_id,
+            "arn:aws:secretsmanager:us-west-2:123456789012:secret:MySecret-AbCdEf"
+        );
+        assert!(config.prefetch().secrets[0].role_arn.is_none());
+        assert_eq!(
+            config.prefetch().secrets[1].secret_id,
+            "arn:aws:secretsmanager:us-east-1:987654321098:secret:CrossAccount-AbCdEf"
+        );
+        assert_eq!(
+            config.prefetch().secrets[1].role_arn.as_deref(),
+            Some("arn:aws:iam::987654321098:role/SecretAccessRole")
+        );
+
+        // Prefetch tag filters
+        assert_eq!(config.prefetch().filter_tags.len(), 2);
+        assert_eq!(config.prefetch().filter_tags[0].key, "Environment");
+        assert!(config.prefetch().filter_tags[0].role_arn.is_none());
+        assert_eq!(config.prefetch().filter_tags[1].key, "Team");
+        assert_eq!(
+            config.prefetch().filter_tags[1].role_arn.as_deref(),
+            Some("arn:aws:iam::987654321098:role/TagRole")
+        );
     }
 }

--- a/aws_secretsmanager_agent/src/constants.rs
+++ b/aws_secretsmanager_agent/src/constants.rs
@@ -13,6 +13,8 @@ pub const EMPTY_ENV_LIST_MSG: &str =
 pub const BAD_PREFIX_MSG: &str =
     "The path prefix specified in the configuration file must begin with /.";
 pub const BAD_MAX_ROLES_MSG: &str = "The maximum number of roles specified in the configuration file isn't valid. The maximum number of roles must be in the range 1 to 20.";
+pub const INVALID_CACHE_BUFFER_RATIO_MSG: &str = "The cache_buffer_ratio specified in the prefetch configuration isn't valid. The cache_buffer_ratio must be between 0.1 and 1.0.";
+pub const INVALID_MAX_JITTER_MSG: &str = "The max_jitter_seconds specified in the prefetch configuration isn't valid. The max_jitter_seconds must be in the range 0 to 10.";
 
 /// Other constants that are used across the code base.
 

--- a/aws_secretsmanager_agent/src/main.rs
+++ b/aws_secretsmanager_agent/src/main.rs
@@ -12,6 +12,7 @@ use server::Server;
 mod config;
 mod constants;
 mod logging;
+mod prefetch;
 mod utils;
 
 use config::Config;
@@ -95,6 +96,12 @@ async fn run<S: FnMut(&SocketAddr), E: FnMut() -> bool>(
     let (cfg, listener) = init(args).await;
     let addr = listener.local_addr()?;
     let svr = Server::new(listener, &cfg).await?;
+
+    // Start prefetch background task if enabled
+    if cfg.prefetch().is_enabled() {
+        info!("Pre-fetch enabled, starting background task");
+        prefetch::start_prefetch_task(svr.cache_manager(), cfg.clone());
+    }
 
     report(&addr); // Report the port used.
 

--- a/aws_secretsmanager_agent/src/prefetch.rs
+++ b/aws_secretsmanager_agent/src/prefetch.rs
@@ -1,0 +1,630 @@
+use crate::cache_manager::CacheManager;
+use crate::config::{Config, SecretPrefetchConfig, TagFilter};
+use aws_sdk_secretsmanager::types::{Filter, FilterNameStringType};
+use log::{debug, error, info, warn};
+use rand::RngExt;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::time::{sleep, Duration};
+
+/// Maximum number of secrets per BatchGetSecretValue call.
+const BATCH_SIZE: usize = 20;
+
+/// Rate limiting delay between batch calls (~30 TPS).
+const BATCH_DELAY_MS: u64 = 34;
+
+/// Format role ARN for log messages. Shows "default credentials" for None.
+fn role_display(role_arn: Option<&str>) -> &str {
+    role_arn.unwrap_or("default credentials")
+}
+
+/// Tracks success and failure counts across the prefetch operation.
+#[derive(Debug, Default)]
+struct PrefetchStats {
+    success: usize,
+    failed: usize,
+}
+
+/// Spawn the prefetch background task.
+///
+/// Adds random jitter (0 to max_jitter_seconds) to prevent fleet-wide synchronized
+/// API calls, then runs the prefetch logic. Default jitter is 0 (no delay).
+///
+/// # Arguments
+///
+/// * `cache_manager` - Shared reference to the cache manager (same instance the server uses).
+/// * `config` - Agent configuration containing prefetch settings and cache size.
+pub fn start_prefetch_task(cache_manager: Arc<CacheManager>, config: Config) {
+    tokio::spawn(async move {
+        let max_jitter = config.prefetch().max_jitter_seconds;
+        if max_jitter > 0 {
+            let jitter = rand::rng().random_range(0.0..max_jitter as f64);
+            sleep(Duration::from_secs_f64(jitter)).await;
+        }
+
+        let mut stats = PrefetchStats::default();
+        run_prefetch(&cache_manager, &config, &mut stats).await;
+
+        info!(
+            "Pre-fetch complete: success={}, failed={}",
+            stats.success, stats.failed
+        );
+    });
+}
+
+/// Run the prefetch logic: resolve secrets from config, group by role, and fetch.
+///
+/// Two independent paths are executed:
+/// 1. Explicit secrets from `prefetch.secrets` — fetched via BatchGetSecretValue with SecretIdList.
+/// 2. Tag-based secrets from `prefetch.filter_tags` — fetched via BatchGetSecretValue with Filters.
+///
+/// # Arguments
+///
+/// * `cm` - The cache manager providing per-role caching clients.
+/// * `config` - Agent configuration with prefetch settings and cache size.
+/// * `stats` - Mutable stats tracker updated throughout the operation.
+async fn run_prefetch(cm: &CacheManager, config: &Config, stats: &mut PrefetchStats) {
+    let cache_size: usize = config.cache_size().into();
+    let warmup_limit = ((cache_size as f32 * config.prefetch().cache_buffer_ratio) as usize).max(1);
+    let prefetch = config.prefetch();
+
+    // Track remaining capacity per role across both paths to prevent
+    // exceeding cache_buffer_ratio when the same role appears in both
+    // prefetch.secrets and prefetch.filter_tags.
+    let mut remaining_by_role: HashMap<Option<String>, usize> = HashMap::new();
+
+    // Path 1: Explicit secrets grouped by role_arn
+    if !prefetch.secrets.is_empty() {
+        let grouped = group_secrets_by_role(&prefetch.secrets);
+        for (role_arn, secret_ids) in &grouped {
+            let remaining = remaining_by_role
+                .entry(role_arn.clone())
+                .or_insert(warmup_limit);
+            fetch_secret_id_group(cm, role_arn.as_deref(), secret_ids, remaining, stats).await;
+        }
+    }
+
+    // Path 2: Tag-based filtering grouped by role_arn
+    if !prefetch.filter_tags.is_empty() {
+        let grouped = group_tags_by_role(&prefetch.filter_tags);
+        for (role_arn, keys) in &grouped {
+            let remaining = remaining_by_role
+                .entry(role_arn.clone())
+                .or_insert(warmup_limit);
+            if *remaining == 0 {
+                continue;
+            }
+            fetch_tag_group(cm, role_arn.as_deref(), keys, remaining, stats).await;
+        }
+    }
+}
+
+/// Group explicit secrets by role_arn for batching.
+///
+/// Secrets without a role_arn are grouped under `None` (default credentials).
+/// Secrets sharing the same role_arn are batched together so they use the
+/// same caching client.
+///
+/// # Arguments
+///
+/// * `secrets` - The list of secret configurations from the prefetch config.
+///
+/// # Returns
+///
+/// * `HashMap<Option<String>, Vec<String>>` - Secret IDs grouped by role ARN.
+fn group_secrets_by_role(secrets: &[SecretPrefetchConfig]) -> HashMap<Option<String>, Vec<String>> {
+    let mut grouped: HashMap<Option<String>, Vec<String>> = HashMap::new();
+    for s in secrets {
+        grouped
+            .entry(s.role_arn.clone())
+            .or_default()
+            .push(s.secret_id.clone());
+    }
+    grouped
+}
+
+/// Group tag filters by role_arn for batching.
+///
+/// Tags without a role_arn are grouped under `None` (default credentials).
+/// Tags sharing the same role_arn are combined into a single
+/// BatchGetSecretValue call with multiple Filters.
+///
+/// # Arguments
+///
+/// * `tags` - The list of tag filter configurations from the prefetch config.
+///
+/// # Returns
+///
+/// * `HashMap<Option<String>, Vec<String>>` - Tag keys grouped by role ARN.
+fn group_tags_by_role(tags: &[TagFilter]) -> HashMap<Option<String>, Vec<String>> {
+    let mut grouped: HashMap<Option<String>, Vec<String>> = HashMap::new();
+    for t in tags {
+        grouped
+            .entry(t.role_arn.clone())
+            .or_default()
+            .push(t.key.clone());
+    }
+    grouped
+}
+
+/// Fetch explicit secrets using BatchGetSecretValue with SecretIdList.
+///
+/// Obtains the appropriate caching client for the role (or default), chunks
+/// the secret IDs into batches of 20, and calls BatchGetSecretValue for each
+/// chunk. Respects the warmup_limit to avoid filling the cache beyond the
+/// configured buffer ratio.
+///
+/// # Arguments
+///
+/// * `cm` - The cache manager providing per-role caching clients.
+/// * `role_arn` - Optional IAM role ARN. `None` uses default credentials.
+/// * `secret_ids` - The secret IDs to fetch.
+/// * `remaining` - Mutable remaining capacity for this role group (shared across paths).
+/// * `stats` - Mutable stats tracker.
+async fn fetch_secret_id_group(
+    cm: &CacheManager,
+    role_arn: Option<&str>,
+    secret_ids: &[String],
+    remaining: &mut usize,
+    stats: &mut PrefetchStats,
+) {
+    let client = match cm.get_client(role_arn).await {
+        Ok(c) => c,
+        Err(e) => {
+            error!(
+                "Pre-fetch: failed to get client for {}: {}",
+                role_display(role_arn),
+                e.1
+            );
+            stats.failed += secret_ids.len();
+            return;
+        }
+    };
+
+    let total = secret_ids.len();
+    let mut processed = 0;
+
+    for chunk in secret_ids.chunks(BATCH_SIZE) {
+        if *remaining == 0 {
+            warn!(
+                "Pre-fetch: cache buffer limit reached for {}, {} secret(s) not fetched",
+                role_display(role_arn),
+                total - processed
+            );
+            break;
+        }
+
+        let truncated = chunk.len() > *remaining;
+        let batch_size = chunk.len().min(*remaining);
+        if truncated {
+            warn!(
+                "Pre-fetch: cache buffer limit reached for {}, {} secret(s) not fetched",
+                role_display(role_arn),
+                total - processed - batch_size
+            );
+        }
+        let batch: Vec<String> = chunk[..batch_size].to_vec();
+        let batch_len = batch.len();
+
+        match client
+            .batch_get_secret_value(Some(batch), None, None, None)
+            .await
+        {
+            Ok(Some(resp)) => {
+                let fetched = resp.secret_values().len();
+                stats.success += fetched;
+                stats.failed += resp.errors().len();
+                *remaining = remaining.saturating_sub(fetched);
+                for err in resp.errors() {
+                    debug!(
+                        "Pre-fetch: failed to fetch {}: {}",
+                        err.secret_id().unwrap_or("unknown"),
+                        err.error_code().unwrap_or("unknown")
+                    );
+                }
+            }
+            Ok(None) => {
+                stats.failed += batch_len;
+            }
+            Err(e) => {
+                error!("Pre-fetch: BatchGetSecretValue failed: {}", e);
+                stats.failed += batch_len;
+            }
+        }
+
+        processed += batch_len;
+
+        if truncated {
+            break;
+        }
+
+        if *remaining > 0 {
+            sleep(Duration::from_millis(BATCH_DELAY_MS)).await;
+        }
+    }
+}
+
+/// Fetch tag-based secrets using BatchGetSecretValue with Filters.
+///
+/// Obtains the appropriate caching client for the role (or default), builds
+/// tag key filters, and calls BatchGetSecretValue with pagination. Each page
+/// discovers and caches secrets matching the tag keys. Respects the
+/// warmup_limit to avoid filling the cache beyond the configured buffer ratio.
+///
+/// # Arguments
+///
+/// * `cm` - The cache manager providing per-role caching clients.
+/// * `role_arn` - Optional IAM role ARN. `None` uses default credentials.
+/// * `keys` - The tag keys to filter by.
+/// * `remaining` - Mutable remaining capacity for this role group (shared across paths).
+/// * `stats` - Mutable stats tracker.
+async fn fetch_tag_group(
+    cm: &CacheManager,
+    role_arn: Option<&str>,
+    keys: &[String],
+    remaining: &mut usize,
+    stats: &mut PrefetchStats,
+) {
+    let client = match cm.get_client(role_arn).await {
+        Ok(c) => c,
+        Err(e) => {
+            error!(
+                "Pre-fetch: failed to get client for {}: {}",
+                role_display(role_arn),
+                e.1
+            );
+            return;
+        }
+    };
+
+    let filters: Vec<Filter> = keys
+        .iter()
+        .map(|k| {
+            Filter::builder()
+                .key(FilterNameStringType::TagKey)
+                .values(k)
+                .build()
+        })
+        .collect();
+
+    let mut next_token: Option<String> = None;
+
+    loop {
+        if *remaining == 0 {
+            warn!(
+                "Pre-fetch: cache buffer limit reached for {}",
+                role_display(role_arn)
+            );
+            break;
+        }
+
+        let max_results = (*remaining as i32).min(BATCH_SIZE as i32);
+
+        match client
+            .batch_get_secret_value(None, Some(filters.clone()), Some(max_results), next_token)
+            .await
+        {
+            Ok(Some(resp)) => {
+                let fetched = resp.secret_values().len();
+                stats.success += fetched;
+                stats.failed += resp.errors().len();
+                *remaining = remaining.saturating_sub(fetched);
+
+                for err in resp.errors() {
+                    debug!(
+                        "Pre-fetch: failed to fetch {}: {}",
+                        err.secret_id().unwrap_or("unknown"),
+                        err.error_code().unwrap_or("unknown")
+                    );
+                }
+
+                if fetched == 0 && resp.errors().is_empty() {
+                    warn!("Pre-fetch: no secrets found for tag filters {:?}", keys);
+                }
+
+                next_token = resp.next_token().map(String::from);
+            }
+            Ok(None) => break,
+            Err(e) => {
+                error!("Pre-fetch: BatchGetSecretValue with filters failed: {}", e);
+                break;
+            }
+        }
+
+        if next_token.is_none() {
+            break;
+        }
+        sleep(Duration::from_millis(BATCH_DELAY_MS)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+
+    // Helper to create a CacheManager from a config file (uses the mocked SDK client).
+    async fn cm(config_path: &str) -> (Arc<CacheManager>, Config) {
+        let cfg = Config::new(Some(config_path)).expect("config failed");
+        let cm = CacheManager::new(&cfg).await.expect("cache manager failed");
+        (Arc::new(cm), cfg)
+    }
+
+    #[test]
+    fn test_group_secrets_no_roles() {
+        let secrets = vec![
+            SecretPrefetchConfig {
+                secret_id: "s1".into(),
+                role_arn: None,
+            },
+            SecretPrefetchConfig {
+                secret_id: "s2".into(),
+                role_arn: None,
+            },
+        ];
+        let grouped = group_secrets_by_role(&secrets);
+        assert_eq!(grouped.len(), 1);
+        assert_eq!(grouped[&None].len(), 2);
+    }
+
+    #[test]
+    fn test_group_secrets_mixed_roles() {
+        let secrets = vec![
+            SecretPrefetchConfig {
+                secret_id: "s1".into(),
+                role_arn: None,
+            },
+            SecretPrefetchConfig {
+                secret_id: "s2".into(),
+                role_arn: Some("arn:aws:iam::111:role/A".into()),
+            },
+            SecretPrefetchConfig {
+                secret_id: "s3".into(),
+                role_arn: Some("arn:aws:iam::111:role/A".into()),
+            },
+            SecretPrefetchConfig {
+                secret_id: "s4".into(),
+                role_arn: Some("arn:aws:iam::222:role/B".into()),
+            },
+        ];
+        let grouped = group_secrets_by_role(&secrets);
+        assert_eq!(grouped.len(), 3);
+        assert_eq!(grouped[&None].len(), 1);
+        assert_eq!(grouped[&Some("arn:aws:iam::111:role/A".into())].len(), 2);
+        assert_eq!(grouped[&Some("arn:aws:iam::222:role/B".into())].len(), 1);
+    }
+
+    #[test]
+    fn test_group_tags_no_roles() {
+        let tags = vec![
+            TagFilter {
+                key: "Env".into(),
+                role_arn: None,
+            },
+            TagFilter {
+                key: "Team".into(),
+                role_arn: None,
+            },
+        ];
+        let grouped = group_tags_by_role(&tags);
+        assert_eq!(grouped.len(), 1);
+        assert_eq!(grouped[&None].len(), 2);
+    }
+
+    #[test]
+    fn test_group_tags_mixed_roles() {
+        let tags = vec![
+            TagFilter {
+                key: "Env".into(),
+                role_arn: None,
+            },
+            TagFilter {
+                key: "Team".into(),
+                role_arn: Some("arn:aws:iam::111:role/A".into()),
+            },
+            TagFilter {
+                key: "App".into(),
+                role_arn: Some("arn:aws:iam::111:role/A".into()),
+            },
+        ];
+        let grouped = group_tags_by_role(&tags);
+        assert_eq!(grouped.len(), 2);
+        assert_eq!(grouped[&None].len(), 1);
+        assert_eq!(grouped[&Some("arn:aws:iam::111:role/A".into())].len(), 2);
+    }
+
+    // Verify prefetch with explicit secrets populates the cache.
+    #[tokio::test]
+    async fn test_fetch_secret_id_group_success() {
+        let (cm, _) = cm("tests/resources/configs/config_file_prefetch_functional.toml").await;
+        let mut stats = PrefetchStats::default();
+
+        fetch_secret_id_group(&cm, None, &["MyTest".to_string()], &mut 100, &mut stats).await;
+
+        assert_eq!(stats.success, 1);
+        assert_eq!(stats.failed, 0);
+
+        // Verify the secret is actually in the cache (not a fetch-on-miss)
+        let client = cm.get_client(None).await.unwrap();
+        assert!(client.cache_contains("MyTest").await);
+    }
+
+    // Verify prefetch with a role_arn creates a role client and caches the secret.
+    #[tokio::test]
+    async fn test_fetch_secret_id_group_with_role() {
+        let (cm, _) = cm("tests/resources/configs/config_file_prefetch_functional.toml").await;
+        let mut stats = PrefetchStats::default();
+        let role = "arn:aws:iam::123456789012:role/TestRole";
+
+        fetch_secret_id_group(
+            &cm,
+            Some(role),
+            &["MyTest".to_string()],
+            &mut 100,
+            &mut stats,
+        )
+        .await;
+
+        assert_eq!(stats.success, 1);
+        assert_eq!(stats.failed, 0);
+
+        // Verify the secret is in the role client's cache
+        let client = cm.get_client(Some(role)).await.unwrap();
+        assert!(client.cache_contains("MyTest").await);
+    }
+
+    // Verify prefetch stops when warmup_limit is zero.
+    #[tokio::test]
+    async fn test_fetch_secret_id_group_buffer_limit() {
+        let (cm, _) = cm("tests/resources/configs/config_file_prefetch_functional.toml").await;
+        let mut stats = PrefetchStats::default();
+
+        fetch_secret_id_group(
+            &cm,
+            None,
+            &["MyTest".to_string(), "MyTest2".to_string()],
+            &mut 0,
+            &mut stats,
+        )
+        .await;
+
+        assert_eq!(stats.success, 0);
+    }
+
+    // Verify run_prefetch orchestrates correctly with a secrets config.
+    #[tokio::test]
+    async fn test_run_prefetch_with_secrets() {
+        let (cm, cfg) = cm("tests/resources/configs/config_file_prefetch_functional.toml").await;
+        let mut stats = PrefetchStats::default();
+
+        run_prefetch(&cm, &cfg, &mut stats).await;
+
+        assert_eq!(stats.success, 1);
+        assert_eq!(stats.failed, 0);
+    }
+
+    // Verify run_prefetch is a no-op with empty config.
+    #[tokio::test]
+    async fn test_run_prefetch_empty_config() {
+        let (cm, cfg) = cm("tests/resources/configs/config_file_anyport.toml").await;
+        let mut stats = PrefetchStats::default();
+
+        run_prefetch(&cm, &cfg, &mut stats).await;
+
+        assert_eq!(stats.success, 0);
+        assert_eq!(stats.failed, 0);
+    }
+
+    // Verify API-level batch error is handled gracefully.
+    #[tokio::test]
+    async fn test_fetch_secret_id_group_api_error() {
+        let (cm, _) = cm("tests/resources/configs/config_file_prefetch_functional.toml").await;
+        let mut stats = PrefetchStats::default();
+
+        fetch_secret_id_group(
+            &cm,
+            None,
+            &["BATCHAPIERROR_secret".to_string()],
+            &mut 100,
+            &mut stats,
+        )
+        .await;
+
+        assert_eq!(stats.success, 0);
+        assert_eq!(stats.failed, 1);
+    }
+
+    // Verify partial batch failure: some secrets succeed, some fail.
+    #[tokio::test]
+    async fn test_fetch_secret_id_group_partial_failure() {
+        let (cm, _) = cm("tests/resources/configs/config_file_prefetch_functional.toml").await;
+        let mut stats = PrefetchStats::default();
+
+        fetch_secret_id_group(
+            &cm,
+            None,
+            &["NOTFOUNDsecret".to_string(), "ValidSecret".to_string()],
+            &mut 100,
+            &mut stats,
+        )
+        .await;
+
+        assert_eq!(stats.success, 1);
+        assert_eq!(stats.failed, 1);
+    }
+
+    // Verify tag-based prefetch discovers and caches secrets.
+    #[tokio::test]
+    async fn test_fetch_tag_group_success() {
+        let (cm, _) = cm("tests/resources/configs/config_file_prefetch_functional.toml").await;
+        let mut stats = PrefetchStats::default();
+
+        fetch_tag_group(
+            &cm,
+            None,
+            &["Environment".to_string()],
+            &mut 100,
+            &mut stats,
+        )
+        .await;
+
+        assert_eq!(stats.success, 1);
+        assert_eq!(stats.failed, 0);
+
+        // Verify the tagged secret is in the cache
+        let client = cm.get_client(None).await.unwrap();
+        assert!(client.cache_contains("TaggedSecret").await);
+    }
+
+    // Verify total = success + failed when get_client() fails (max_roles exceeded).
+    #[tokio::test]
+    async fn test_fetch_secret_id_group_client_failure_counts_total() {
+        // Use max_roles=2 config, fill both slots, then a third role fails
+        let (cm, _) = cm("tests/resources/configs/config_file_max_roles_2.toml").await;
+        let mut stats = PrefetchStats::default();
+
+        // Fill both role slots
+        fetch_secret_id_group(
+            &cm,
+            Some("arn:aws:iam::111111111111:role/Role1"),
+            &["MyTest".to_string()],
+            &mut 100,
+            &mut stats,
+        )
+        .await;
+        fetch_secret_id_group(
+            &cm,
+            Some("arn:aws:iam::222222222222:role/Role2"),
+            &["MyTest".to_string()],
+            &mut 100,
+            &mut stats,
+        )
+        .await;
+
+        // Third role exceeds max_roles — get_client() returns Err
+        let mut stats3 = PrefetchStats::default();
+        fetch_secret_id_group(
+            &cm,
+            Some("arn:aws:iam::333333333333:role/Role3"),
+            &["MyTest".to_string(), "MyTest2".to_string()],
+            &mut 100,
+            &mut stats3,
+        )
+        .await;
+
+        // Both secrets should be counted in total and failed
+        assert_eq!(stats3.failed, 2);
+        assert_eq!(stats3.success, 0);
+    }
+
+    // Verify tag-based prefetch respects buffer limit.
+    #[tokio::test]
+    async fn test_fetch_tag_group_buffer_limit() {
+        let (cm, _) = cm("tests/resources/configs/config_file_prefetch_functional.toml").await;
+        let mut stats = PrefetchStats::default();
+
+        fetch_tag_group(&cm, None, &["Env".to_string()], &mut 0, &mut stats).await;
+
+        assert_eq!(stats.success, 0);
+    }
+}

--- a/aws_secretsmanager_agent/src/server.rs
+++ b/aws_secretsmanager_agent/src/server.rs
@@ -57,6 +57,11 @@ impl Server {
         })
     }
 
+    /// Returns a clone of the Arc<CacheManager> for use by the prefetch task.
+    pub fn cache_manager(&self) -> Arc<CacheManager> {
+        self.cache_mgr.clone()
+    }
+
     /// Accept the next request on the listener and process it in a separate thread.
     ///
     /// # Returns

--- a/aws_secretsmanager_agent/src/utils.rs
+++ b/aws_secretsmanager_agent/src/utils.rs
@@ -17,7 +17,8 @@ use tests::var_test as var;
 ///
 /// Callers need to pass in the error code (e.g.  InternalFailure,
 /// InvalidParameterException, ect.) and the error message. This function will
-/// then format a response body in JSON 1.1 format.
+/// then format a response body in JSON 1.1 format. All values are properly
+/// JSON-escaped via serde_json to prevent injection attacks.
 ///
 /// # Arguments
 ///
@@ -42,7 +43,11 @@ pub fn err_response(err_code: &str, msg: &str) -> String {
     if msg.is_empty() || err_code == "InternalFailure" {
         return String::from("{\"__type\":\"InternalFailure\"}");
     }
-    format!("{{\"__type\":\"{err_code}\", \"message\":\"{msg}\"}}")
+    serde_json::json!({
+        "__type": err_code,
+        "message": msg
+    })
+    .to_string()
 }
 
 /// Helper function to get the SSRF token value.

--- a/aws_secretsmanager_agent/tests/resources/configs/config_file_full_with_prefetch.toml
+++ b/aws_secretsmanager_agent/tests/resources/configs/config_file_full_with_prefetch.toml
@@ -1,0 +1,28 @@
+# Full config with all original parameters plus prefetch
+log_level = "debug"
+http_port = "65535"
+ttl_seconds = "600"
+cache_size = "500"
+ssrf_headers = ["X-Aws-Parameters-Secrets-Token"]
+ssrf_env_variables = ["MY_TOKEN"]
+path_prefix = "/custom/"
+max_conn = "100"
+max_roles = "10"
+region = "us-east-1"
+ignore_transient_errors = false
+validate_credentials = false
+
+[prefetch]
+cache_buffer_ratio = 0.6
+
+filter_tags = [
+  { key = "Environment" },
+  { key = "Team", role_arn = "arn:aws:iam::987654321098:role/TagRole" },
+]
+
+[[prefetch.secrets]]
+secret_id = "arn:aws:secretsmanager:us-west-2:123456789012:secret:MySecret-AbCdEf"
+
+[[prefetch.secrets]]
+secret_id = "arn:aws:secretsmanager:us-east-1:987654321098:secret:CrossAccount-AbCdEf"
+role_arn = "arn:aws:iam::987654321098:role/SecretAccessRole"

--- a/aws_secretsmanager_agent/tests/resources/configs/config_file_prefetch_both.toml
+++ b/aws_secretsmanager_agent/tests/resources/configs/config_file_prefetch_both.toml
@@ -1,0 +1,8 @@
+[prefetch]
+cache_buffer_ratio = 0.5
+filter_tags = [
+  { key = "Environment" },
+]
+
+[[prefetch.secrets]]
+secret_id = "arn:aws:secretsmanager:us-west-2:123456789012:secret:MySecret-AbCdEf"

--- a/aws_secretsmanager_agent/tests/resources/configs/config_file_prefetch_empty.toml
+++ b/aws_secretsmanager_agent/tests/resources/configs/config_file_prefetch_empty.toml
@@ -1,0 +1,1 @@
+[prefetch]

--- a/aws_secretsmanager_agent/tests/resources/configs/config_file_prefetch_functional.toml
+++ b/aws_secretsmanager_agent/tests/resources/configs/config_file_prefetch_functional.toml
@@ -1,0 +1,8 @@
+# Config for prefetch functional tests
+http_port = "0"
+
+[prefetch]
+cache_buffer_ratio = 0.8
+
+[[prefetch.secrets]]
+secret_id = "MyTest"

--- a/aws_secretsmanager_agent/tests/resources/configs/config_file_prefetch_inline.toml
+++ b/aws_secretsmanager_agent/tests/resources/configs/config_file_prefetch_inline.toml
@@ -1,0 +1,5 @@
+[prefetch]
+secrets = [
+  { secret_id = "arn:aws:secretsmanager:us-west-2:123456789012:secret:MySecret-AbCdEf" },
+  { secret_id = "cross-account-secret", role_arn = "arn:aws:iam::987654321098:role/SecretAccessRole" },
+]

--- a/aws_secretsmanager_agent/tests/resources/configs/config_file_prefetch_jitter.toml
+++ b/aws_secretsmanager_agent/tests/resources/configs/config_file_prefetch_jitter.toml
@@ -1,0 +1,5 @@
+[prefetch]
+max_jitter_seconds = 5
+
+[[prefetch.secrets]]
+secret_id = "MyTest"

--- a/aws_secretsmanager_agent/tests/resources/configs/config_file_prefetch_secrets.toml
+++ b/aws_secretsmanager_agent/tests/resources/configs/config_file_prefetch_secrets.toml
@@ -1,0 +1,6 @@
+[[prefetch.secrets]]
+secret_id = "arn:aws:secretsmanager:us-west-2:123456789012:secret:MySecret-AbCdEf"
+
+[[prefetch.secrets]]
+secret_id = "arn:aws:secretsmanager:us-east-1:987654321098:secret:CrossAccountSecret-AbCdEf"
+role_arn = "arn:aws:iam::987654321098:role/SecretAccessRole"

--- a/aws_secretsmanager_agent/tests/resources/configs/config_file_prefetch_tags.toml
+++ b/aws_secretsmanager_agent/tests/resources/configs/config_file_prefetch_tags.toml
@@ -1,0 +1,5 @@
+[prefetch]
+filter_tags = [
+  { key = "Environment" },
+  { key = "Team", role_arn = "arn:aws:iam::987654321098:role/SecretAccessRole" },
+]

--- a/aws_secretsmanager_caching/Cargo.toml
+++ b/aws_secretsmanager_caching/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 
 [features]
 fips = ["rustls/fips"]
+test-util = []
 
 [dependencies]
 aws-sdk-secretsmanager = "1"

--- a/aws_secretsmanager_caching/src/lib.rs
+++ b/aws_secretsmanager_caching/src/lib.rs
@@ -16,14 +16,16 @@ pub mod secret_store;
 mod utils;
 
 use aws_config::BehaviorVersion;
+use aws_sdk_secretsmanager::operation::batch_get_secret_value::BatchGetSecretValueOutput;
+use aws_sdk_secretsmanager::types::Filter;
 use aws_sdk_secretsmanager::Client as SecretsManagerClient;
 use error::is_transient_error;
 use secret_store::SecretStoreError;
 
 #[cfg(debug_assertions)]
-use log::info;
+use log::{info, warn};
 
-use output::GetSecretValueOutputDef;
+use output::{BlobDef, GetSecretValueOutputDef};
 use secret_store::{MemoryStore, SecretStore};
 
 #[cfg(debug_assertions)]
@@ -284,6 +286,95 @@ impl SecretsManagerCachingClient {
         }
     }
 
+    /// Batch fetch secrets from Secrets Manager and write them to the cache.
+    ///
+    /// Calls the BatchGetSecretValue API, converts successful results to
+    /// `GetSecretValueOutputDef`, and writes them to the internal store under
+    /// a single write lock. Per-secret errors are logged as warnings but do
+    /// not stop the operation.
+    ///
+    /// # Arguments
+    ///
+    /// * `secret_id_list` - Secret ARNs or names to retrieve. Mutually exclusive with `filters`.
+    /// * `filters` - Tag-based filters for discovery. Mutually exclusive with `secret_id_list`.
+    /// * `max_results` - Maximum number of results per page (up to 20).
+    /// * `next_token` - Pagination token from a previous call.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(output))` - The raw SDK response for the caller to inspect (next_token, errors).
+    /// * `Ok(None)` - A transient error was suppressed (when `ignore_transient_errors` is true).
+    /// * `Err(...)` - A non-transient SDK error.
+    pub async fn batch_get_secret_value(
+        &self,
+        secret_id_list: Option<Vec<String>>,
+        filters: Option<Vec<Filter>>,
+        max_results: Option<i32>,
+        next_token: Option<String>,
+    ) -> Result<Option<BatchGetSecretValueOutput>, Box<dyn Error>> {
+        let response = match self
+            .asm_client
+            .batch_get_secret_value()
+            .set_secret_id_list(secret_id_list)
+            .set_filters(filters)
+            .set_max_results(max_results)
+            .set_next_token(next_token)
+            .send()
+            .await
+        {
+            Ok(resp) => resp,
+            Err(e) if self.ignore_transient_errors && is_transient_error(&e) => {
+                return Ok(None);
+            }
+            Err(e) => return Err(Box::new(e)),
+        };
+
+        // Convert SecretValueEntry → GetSecretValueOutputDef
+        let mut to_cache: Vec<(String, GetSecretValueOutputDef)> = Vec::new();
+        for entry in response.secret_values() {
+            if let Some(name) = entry.name() {
+                to_cache.push((
+                    name.to_owned(),
+                    GetSecretValueOutputDef {
+                        arn: entry.arn().map(String::from),
+                        name: Some(name.to_owned()),
+                        version_id: entry.version_id().map(String::from),
+                        secret_string: entry.secret_string().map(String::from),
+                        secret_binary: entry
+                            .secret_binary()
+                            .map(|b| BlobDef::new(b.clone().into_inner())),
+                        version_stages: Some(entry.version_stages().to_vec()),
+                        created_date: entry
+                            .created_date()
+                            .copied()
+                            .and_then(|dt| std::time::SystemTime::try_from(dt).ok()),
+                    },
+                ));
+            }
+        }
+
+        // Log per-secret errors
+        #[cfg(debug_assertions)]
+        {
+            for err in response.errors() {
+                warn!(
+                    "BatchGetSecretValue failed for {}: {}",
+                    err.secret_id().unwrap_or("unknown"),
+                    err.error_code().unwrap_or("unknown")
+                );
+            }
+        }
+
+        // Write all secrets under a single lock acquisition
+        let mut store = self.store.write().await;
+        for (name, secret) in to_cache {
+            store.write_secret_value(name, None, None, secret)?;
+        }
+        drop(store);
+
+        Ok(Some(response))
+    }
+
     /// Refreshes the secret value through a GetSecretValue call to ASM
     ///
     /// # Arguments
@@ -428,6 +519,16 @@ impl SecretsManagerCachingClient {
     #[cfg(debug_assertions)]
     fn get_counter_value(&self, counter: &AtomicU32) -> u32 {
         counter.load(Ordering::Relaxed)
+    }
+
+    /// Check if a secret exists in the cache
+    ///
+    /// Reads directly from the store — returns true if the key is present and
+    /// not expired, false otherwise. Only available in test builds.
+    #[cfg(any(test, feature = "test-util"))]
+    pub async fn cache_contains(&self, secret_id: &str) -> bool {
+        let store = self.store.read().await;
+        store.get_secret_value(secret_id, None, None).is_ok()
     }
 }
 
@@ -905,6 +1006,94 @@ mod tests {
         assert_eq!(response1.version_stages, response2.version_stages);
     }
 
+    #[tokio::test]
+    async fn test_batch_get_secret_value_success() {
+        let client = fake_client(None, false, None, None);
+
+        // Mock returns one secret per batch call (keyed on first ID)
+        let result = client
+            .batch_get_secret_value(Some(vec!["MyTest".to_string()]), None, None, None)
+            .await;
+
+        assert!(result.is_ok());
+        let resp = result.unwrap().unwrap();
+        assert_eq!(resp.secret_values().len(), 1);
+        assert!(resp.errors().is_empty());
+
+        // Verify the secret was written to the cache (cache hit, no network call)
+        let cached = client.get_secret_value("MyTest", None, None, false).await;
+        assert!(cached.is_ok());
+        assert_eq!(cached.unwrap().secret_string, Some("hunter2".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_batch_get_secret_value_partial_failure() {
+        let client = fake_client(None, false, None, None);
+
+        let result = client
+            .batch_get_secret_value(
+                Some(vec![
+                    "NOTFOUNDsecret".to_string(),
+                    "ValidSecret".to_string(),
+                ]),
+                None,
+                None,
+                None,
+            )
+            .await;
+
+        assert!(result.is_ok());
+        let resp = result.unwrap().unwrap();
+        // One secret succeeded, one errored
+        assert_eq!(resp.secret_values().len(), 1);
+        assert_eq!(resp.errors().len(), 1);
+
+        // Valid secret should be cached
+        let cached = client
+            .get_secret_value("ValidSecret", None, None, false)
+            .await;
+        assert!(cached.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_batch_get_secret_value_api_error() {
+        let client = fake_client(None, false, None, None);
+
+        let result = client
+            .batch_get_secret_value(
+                Some(vec!["BATCHAPIERROR_secret".to_string()]),
+                None,
+                None,
+                None,
+            )
+            .await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_batch_get_secret_value_transient_suppressed() {
+        use aws_smithy_runtime::client::http::test_util::wire::{ReplayedEvent, WireMockServer};
+
+        let mock = WireMockServer::start(vec![ReplayedEvent::Timeout]).await;
+        let client = fake_client(
+            None,
+            true, // ignore_transient_errors = true
+            Some(mock.http_client()),
+            Some(mock.endpoint_url()),
+        );
+
+        let result = client
+            .batch_get_secret_value(Some(vec!["MyTest".to_string()]), None, None, None)
+            .await;
+
+        mock.shutdown();
+
+        // Transient error should be suppressed → Ok(None)
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
+    }
+
     mod asm_mock {
         use aws_sdk_secretsmanager as secretsmanager;
         use aws_smithy_runtime::client::http::test_util::infallible_client_fn;
@@ -972,12 +1161,104 @@ mod tests {
         "Message": "Internal service error"
         }"###;
 
+        // Template BatchGetSecretValue response for testing
+        const BATCH_GSV_BODY: &str = r###"{
+            "SecretValues": [
+                {
+                    "ARN": "{{arn}}",
+                    "Name": "{{name}}",
+                    "VersionId": "{{version}}",
+                    "SecretString": "{{secret}}",
+                    "VersionStages": ["{{label}}"],
+                    "CreatedDate": 1569534789.046
+                }
+            ],
+            "Errors": []
+        }"###;
+
+        // Template BatchGetSecretValue response with per-secret errors
+        const BATCH_WITH_ERRORS_BODY: &str = r###"{
+            "SecretValues": [
+                {
+                    "ARN": "{{arn}}",
+                    "Name": "{{valid_name}}",
+                    "VersionId": "{{version}}",
+                    "SecretString": "{{secret}}",
+                    "VersionStages": ["{{label}}"],
+                    "CreatedDate": 1569534789.046
+                }
+            ],
+            "Errors": [
+                {
+                    "SecretId": "{{err_name}}",
+                    "ErrorCode": "ResourceNotFoundException",
+                    "Message": "Secrets Manager can't find the specified secret."
+                }
+            ]
+        }"###;
+
+        // Template for BatchGetSecretValue API-level error
+        const BATCH_INVALID_PARAMETER_BODY: &str = r###"{
+            "__type":"InvalidParameterException",
+            "message":"The parameter SecretIdList contains invalid values"
+        }"###;
+
         // Private helper to look at the request and provide the correct response.
         fn format_rsp(req: Request<SdkBody>) -> (u16, String) {
             let (parts, body) = req.into_parts();
+            let target = parts.headers["x-amz-target"].to_str().unwrap();
 
             let req_map: serde_json::Map<String, Value> =
                 serde_json::from_slice(body.bytes().unwrap()).unwrap();
+
+            // Handle BatchGetSecretValue requests
+            if target == "secretsmanager.BatchGetSecretValue" {
+                let secret_ids = req_map
+                    .get("SecretIdList")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>())
+                    .unwrap_or_default();
+                let has_filters = req_map.get("Filters").is_some();
+
+                if secret_ids.iter().any(|s| s.starts_with("BATCHAPIERROR")) {
+                    return (400, BATCH_INVALID_PARAMETER_BODY.to_string());
+                }
+
+                if secret_ids.iter().any(|s| s.starts_with("NOTFOUND")) {
+                    let valid_name = secret_ids
+                        .iter()
+                        .find(|s| !s.starts_with("NOTFOUND"))
+                        .unwrap_or(&"Valid");
+                    let err_name = secret_ids
+                        .iter()
+                        .find(|s| s.starts_with("NOTFOUND"))
+                        .unwrap_or(&"NOTFOUND");
+                    let rsp = BATCH_WITH_ERRORS_BODY
+                        .replace("{{arn}}", &FAKE_ARN.replace("{{name}}", valid_name))
+                        .replace("{{valid_name}}", valid_name)
+                        .replace("{{err_name}}", err_name)
+                        .replace("{{version}}", DEFAULT_VERSION)
+                        .replace("{{secret}}", DEFAULT_SECRET_STRING)
+                        .replace("{{label}}", DEFAULT_LABEL);
+                    return (200, rsp);
+                }
+
+                // For filter-based requests return "TaggedSecret"; for SecretIdList use first ID
+                let name = if has_filters {
+                    "TaggedSecret"
+                } else {
+                    secret_ids.first().unwrap_or(&"MyTest")
+                };
+                let rsp = BATCH_GSV_BODY
+                    .replace("{{arn}}", &FAKE_ARN.replace("{{name}}", name))
+                    .replace("{{name}}", name)
+                    .replace("{{version}}", DEFAULT_VERSION)
+                    .replace("{{secret}}", DEFAULT_SECRET_STRING)
+                    .replace("{{label}}", DEFAULT_LABEL);
+                return (200, rsp);
+            }
+
+            // Existing single-request handling
             let version = req_map
                 .get("VersionId")
                 .map_or(DEFAULT_VERSION, |x| x.as_str().unwrap());
@@ -995,7 +1276,7 @@ mod tests {
                 _ => DEFAULT_SECRET_STRING.to_string(),
             };
 
-            let (code, template) = match parts.headers["x-amz-target"].to_str().unwrap() {
+            let (code, template) = match target {
                 "secretsmanager.GetSecretValue" if name.starts_with("KMSACCESSDENIED") => {
                     (400, KMS_ACCESS_DENIED_BODY)
                 }

--- a/integration-tests/tests/cache_behavior.rs
+++ b/integration-tests/tests/cache_behavior.rs
@@ -13,7 +13,7 @@ use tokio::time::sleep;
 #[tokio::test]
 async fn test_refresh_now_on_updated_secret_succeeds() {
     let secrets = TestSecrets::setup_basic().await;
-    let secret_name: String = secrets.secret_name(SecretType::Basic);
+    let secret_name: String = secrets.secret_name(&SecretType::Basic);
 
     let agent = AgentProcess::start().await;
 
@@ -77,7 +77,7 @@ async fn test_refresh_now_on_updated_secret_succeeds() {
 #[tokio::test]
 async fn test_cache_expiration_and_refresh() {
     let secrets = TestSecrets::setup_basic().await;
-    let secret_name = secrets.secret_name(SecretType::Basic);
+    let secret_name = secrets.secret_name(&SecretType::Basic);
 
     // Start agent with short TTL for faster testing
     const TTL_SECONDS: u64 = 5;
@@ -141,7 +141,7 @@ async fn test_cache_expiration_and_refresh() {
 #[tokio::test]
 async fn test_ttl_zero_disables_caching() {
     let secrets = TestSecrets::setup_basic().await;
-    let secret_name = secrets.secret_name(SecretType::Basic);
+    let secret_name = secrets.secret_name(&SecretType::Basic);
 
     // Start agent with TTL=0 to disable caching
     const TTL_SECONDS: u64 = 0;

--- a/integration-tests/tests/common.rs
+++ b/integration-tests/tests/common.rs
@@ -6,6 +6,7 @@
 
 use aws_config;
 use aws_sdk_secretsmanager;
+use aws_sdk_sts;
 use derive_builder::Builder;
 use std::env;
 use std::fmt;
@@ -16,13 +17,14 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command as TokioCommand;
 use url::Url;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub enum SecretType {
     Basic,
     Binary,
     Versioned,
     Large,
+    Tagged { tag_key: String },
 }
 
 impl fmt::Display for SecretType {
@@ -32,6 +34,7 @@ impl fmt::Display for SecretType {
             SecretType::Binary => write!(f, "binary"),
             SecretType::Versioned => write!(f, "versioned"),
             SecretType::Large => write!(f, "large"),
+            SecretType::Tagged { .. } => write!(f, "tagged"),
         }
     }
 }
@@ -98,6 +101,11 @@ validate_credentials = true
             port, ttl_seconds
         );
 
+        Self::start_with_config_content(port, &config_content).await
+    }
+
+    /// Start the agent with a fully custom config string.
+    pub async fn start_with_config_content(port: u16, config_content: &str) -> AgentProcess {
         let config_path = format!("/tmp/test_config_{}.toml", port);
         std::fs::write(&config_path, config_content).expect("Failed to write test config");
 
@@ -330,13 +338,21 @@ pub struct TestSecrets {
 }
 
 impl TestSecrets {
-    pub fn secret_name(&self, secret_type: SecretType) -> String {
+    pub fn secret_name(&self, secret_type: &SecretType) -> String {
         format!("{}-{}", self.prefix, secret_type)
     }
 
     #[allow(dead_code)]
     pub async fn setup_basic() -> Self {
         Self::setup_with_types(vec![SecretType::Basic]).await
+    }
+
+    #[allow(dead_code)]
+    pub async fn setup_tagged(tag_key: &str) -> Self {
+        Self::setup_with_types(vec![SecretType::Tagged {
+            tag_key: tag_key.to_string(),
+        }])
+        .await
     }
 
     #[allow(dead_code)]
@@ -373,7 +389,7 @@ impl TestSecrets {
         for secret_type in types {
             match secret_type {
                 SecretType::Basic => {
-                    let secret_name = temp_secrets.secret_name(SecretType::Basic);
+                    let secret_name = temp_secrets.secret_name(&SecretType::Basic);
                     client
                         .create_secret()
                         .name(&secret_name)
@@ -384,7 +400,7 @@ impl TestSecrets {
                         .expect("Failed to create test secret");
                 }
                 SecretType::Binary => {
-                    let binary_secret_name = temp_secrets.secret_name(SecretType::Binary);
+                    let binary_secret_name = temp_secrets.secret_name(&SecretType::Binary);
                     let binary_data = b"\x00\x01\x02\x03\xFF\xFE\xFD";
                     client
                         .create_secret()
@@ -396,7 +412,7 @@ impl TestSecrets {
                         .expect("Failed to create binary test secret");
                 }
                 SecretType::Versioned => {
-                    let versioned_secret_name = temp_secrets.secret_name(SecretType::Versioned);
+                    let versioned_secret_name = temp_secrets.secret_name(&SecretType::Versioned);
                     client
                         .create_secret()
                         .name(&versioned_secret_name)
@@ -417,7 +433,7 @@ impl TestSecrets {
                         .expect("Failed to create AWSPENDING version");
                 }
                 SecretType::Large => {
-                    let large_secret_name = temp_secrets.secret_name(SecretType::Large);
+                    let large_secret_name = temp_secrets.secret_name(&SecretType::Large);
                     let large_data = "x".repeat(60000); // ~60KB of data
                     let large_secret_json = format!(r#"{{"data":"{}","size":"60KB"}}"#, large_data);
                     client
@@ -429,6 +445,25 @@ impl TestSecrets {
                         .await
                         .expect("Failed to create large test secret");
                 }
+                SecretType::Tagged { tag_key } => {
+                    let tagged_secret_name = temp_secrets.secret_name(&SecretType::Tagged {
+                        tag_key: tag_key.clone(),
+                    });
+                    client
+                        .create_secret()
+                        .name(&tagged_secret_name)
+                        .description("Tagged test secret for prefetch integration tests")
+                        .secret_string(r#"{"username":"testuser","password":"testpass123"}"#)
+                        .tags(
+                            aws_sdk_secretsmanager::types::Tag::builder()
+                                .key(&tag_key)
+                                .value("integration-testing")
+                                .build(),
+                        )
+                        .send()
+                        .await
+                        .expect("Failed to create tagged test secret");
+                }
             }
         }
 
@@ -436,9 +471,38 @@ impl TestSecrets {
     }
 
     #[allow(dead_code)]
+    pub async fn wait_for_tag(
+        &self,
+        secret_type: &SecretType,
+        expected_tag_key: &str,
+    ) -> Result<(), tokio::time::error::Elapsed> {
+        let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+        let client = aws_sdk_secretsmanager::Client::new(&config);
+        let secret_name = self.secret_name(secret_type);
+
+        tokio::time::timeout(Duration::from_secs(60), async {
+            loop {
+                let response = client
+                    .describe_secret()
+                    .secret_id(&secret_name)
+                    .send()
+                    .await
+                    .expect("Failed to describe secret");
+
+                let tags = response.tags();
+                if tags.iter().any(|t| t.key() == Some(expected_tag_key)) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+        })
+        .await
+    }
+
+    #[allow(dead_code)]
     pub async fn wait_for_pending_version(
         &self,
-        secret_type: SecretType,
+        secret_type: &SecretType,
     ) -> Result<(), tokio::time::error::Elapsed> {
         tokio::time::timeout(Duration::from_secs(10), async {
             loop {
@@ -453,7 +517,7 @@ impl TestSecrets {
     }
 
     #[allow(dead_code)]
-    pub async fn get_version_ids(&self, secret_type: SecretType) -> (String, String) {
+    pub async fn get_version_ids(&self, secret_type: &SecretType) -> (String, String) {
         let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
         let client = aws_sdk_secretsmanager::Client::new(&config);
         let secret_name = self.secret_name(secret_type);
@@ -500,5 +564,57 @@ impl Drop for TestSecrets {
                     .await;
             }
         });
+    }
+}
+
+// ---- Role assumption helpers ----
+
+/// Well-known role names for integration tests.
+pub const TARGET_ROLE_NAME: &str = "secrets-manager-agent";
+#[allow(dead_code)]
+pub const NO_ACCESS_ROLE_NAME: &str = "secrets-manager-agent-no-access";
+
+/// Helper for role-chaining integration tests.
+/// Discovers the account ID and provides role ARN construction with pre-flight validation.
+pub struct RoleChainingHelper {
+    pub client: aws_sdk_sts::Client,
+    pub account_id: String,
+}
+
+impl RoleChainingHelper {
+    #[allow(dead_code)]
+    pub async fn new() -> Self {
+        let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+        let client = aws_sdk_sts::Client::new(&config);
+        let account_id = client
+            .get_caller_identity()
+            .send()
+            .await
+            .expect("Failed to call GetCallerIdentity")
+            .account()
+            .expect("No account ID in response")
+            .to_string();
+        Self { client, account_id }
+    }
+
+    /// Pre-flight check: verify the role can be assumed, panic with a clear message if not.
+    /// Returns the full role ARN on success.
+    #[allow(dead_code)]
+    pub async fn get_role_arn(&self, role_name: &str) -> String {
+        let role_arn = format!("arn:aws:iam::{}:role/{role_name}", self.account_id);
+        self.client
+            .assume_role()
+            .role_arn(&role_arn)
+            .role_session_name("role-chaining-integration-tests")
+            .send()
+            .await
+            .unwrap_or_else(|e| panic!("Failed to assume role {role_name}: {e}"));
+        role_arn
+    }
+
+    /// Build a role ARN without pre-flight validation.
+    #[allow(dead_code)]
+    pub fn build_role_arn(&self, role_name: &str) -> String {
+        format!("arn:aws:iam::{}:role/{role_name}", self.account_id)
     }
 }

--- a/integration-tests/tests/configuration.rs
+++ b/integration-tests/tests/configuration.rs
@@ -35,7 +35,7 @@ async fn test_ping_endpoint_health_check() {
 #[tokio::test]
 async fn test_path_based_requests() {
     let secrets = TestSecrets::setup_basic().await;
-    let secret_name = secrets.secret_name(SecretType::Basic);
+    let secret_name = secrets.secret_name(&SecretType::Basic);
 
     let agent = AgentProcess::start().await;
 

--- a/integration-tests/tests/prefetch.rs
+++ b/integration-tests/tests/prefetch.rs
@@ -1,0 +1,261 @@
+//! # Pre-fetch Integration Tests
+//!
+//! Tests that the agent pre-fetches secrets into the cache at startup.
+//!
+//! Strategy: create a secret, start the agent with prefetch config, wait for
+//! prefetch to complete (jitter + buffer), update the secret via SDK, then
+//! request it from the agent. If prefetch worked, the agent returns the old
+//! (cached) value. If it didn't, the agent fetches fresh and returns the new value.
+
+mod common;
+
+use common::*;
+
+/// Verify that a prefetched secret is served from cache (stale value)
+/// after the underlying secret is updated.
+#[tokio::test]
+async fn test_prefetch_serves_cached_value() {
+    let secrets = TestSecrets::setup_basic().await;
+    let secret_name = secrets.secret_name(&SecretType::Basic);
+
+    // Start agent with prefetch config for this secret, high TTL so cache doesn't expire
+    let port = 2790;
+    let config_content = format!(
+        r#"
+http_port = {}
+log_level = "info"
+ttl_seconds = 300
+validate_credentials = true
+
+[[prefetch.secrets]]
+secret_id = "{}"
+"#,
+        port, secret_name
+    );
+
+    let agent = AgentProcess::start_with_config_content(port, &config_content).await;
+
+    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
+    let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+    let client = aws_sdk_secretsmanager::Client::new(&config);
+
+    let updated_value = r#"{"username":"updateduser","password":"updatedpass"}"#;
+    client
+        .update_secret()
+        .secret_id(&secret_name)
+        .secret_string(updated_value)
+        .send()
+        .await
+        .expect("Failed to update secret");
+
+    let query = AgentQueryBuilder::default()
+        .secret_id(&secret_name)
+        .build()
+        .unwrap();
+
+    let response = agent.make_request(&query).await;
+    let json: serde_json::Value = serde_json::from_str(&response).unwrap();
+
+    // Prefetch cached the original value, so we should see "testuser" not "updateduser"
+    assert!(
+        json["SecretString"].as_str().unwrap().contains("testuser"),
+        "Expected cached (old) value with 'testuser', got: {}",
+        json["SecretString"]
+    );
+}
+
+/// Verify that prefetch with no matching secrets doesn't crash the agent.
+#[tokio::test]
+async fn test_prefetch_nonexistent_secret_doesnt_crash() {
+    let port = 2791;
+    let config_content = format!(
+        r#"
+http_port = {}
+log_level = "info"
+ttl_seconds = 300
+validate_credentials = false
+
+[[prefetch.secrets]]
+secret_id = "nonexistent-secret-that-does-not-exist"
+"#,
+        port
+    );
+
+    let agent = AgentProcess::start_with_config_content(port, &config_content).await;
+
+    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
+    // Agent should still be healthy
+    let response = agent.make_ping_request().await;
+    assert_eq!(response.status(), 200);
+}
+
+/// Verify that inline array syntax for prefetch secrets works the same as array-of-tables.
+#[tokio::test]
+async fn test_prefetch_inline_syntax_serves_cached_value() {
+    let secrets = TestSecrets::setup_basic().await;
+    let secret_name = secrets.secret_name(&SecretType::Basic);
+
+    let port = 2792;
+    let config_content = format!(
+        r#"
+http_port = {}
+log_level = "info"
+ttl_seconds = 300
+validate_credentials = true
+
+[prefetch]
+secrets = [
+  {{ secret_id = "{}" }},
+]
+"#,
+        port, secret_name
+    );
+
+    let agent = AgentProcess::start_with_config_content(port, &config_content).await;
+
+    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
+    let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+    let client = aws_sdk_secretsmanager::Client::new(&config);
+
+    client
+        .update_secret()
+        .secret_id(&secret_name)
+        .secret_string(r#"{"username":"updateduser","password":"updatedpass"}"#)
+        .send()
+        .await
+        .expect("Failed to update secret");
+
+    let query = AgentQueryBuilder::default()
+        .secret_id(&secret_name)
+        .build()
+        .unwrap();
+
+    let response = agent.make_request(&query).await;
+    let json: serde_json::Value = serde_json::from_str(&response).unwrap();
+
+    assert!(
+        json["SecretString"].as_str().unwrap().contains("testuser"),
+        "Expected cached (old) value with 'testuser', got: {}",
+        json["SecretString"]
+    );
+}
+
+/// Verify that a prefetched secret with role_arn is served from cache
+/// after the underlying secret is updated.
+#[tokio::test]
+async fn test_prefetch_with_role_chaining_serves_cached_value() {
+    let helper = RoleChainingHelper::new().await;
+    let role_arn = helper.get_role_arn(TARGET_ROLE_NAME).await;
+
+    let secrets = TestSecrets::setup_basic().await;
+    let secret_name = secrets.secret_name(&SecretType::Basic);
+
+    let port = 2793;
+    let config_content = format!(
+        r#"
+http_port = {}
+log_level = "info"
+ttl_seconds = 300
+validate_credentials = true
+
+[[prefetch.secrets]]
+secret_id = "{}"
+role_arn = "{}"
+"#,
+        port, secret_name, role_arn
+    );
+
+    let agent = AgentProcess::start_with_config_content(port, &config_content).await;
+
+    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
+    let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+    let client = aws_sdk_secretsmanager::Client::new(&config);
+
+    client
+        .update_secret()
+        .secret_id(&secret_name)
+        .secret_string(r#"{"username":"updateduser","password":"updatedpass"}"#)
+        .send()
+        .await
+        .expect("Failed to update secret");
+
+    let query = AgentQueryBuilder::default()
+        .secret_id(&secret_name)
+        .role_arn(&role_arn)
+        .build()
+        .unwrap();
+
+    let response = agent.make_request(&query).await;
+    let json: serde_json::Value = serde_json::from_str(&response).unwrap();
+
+    assert!(
+        json["SecretString"].as_str().unwrap().contains("testuser"),
+        "Expected cached (old) value with 'testuser', got: {}",
+        json["SecretString"]
+    );
+}
+
+/// Verify that tag-based prefetch discovers and caches secrets, serving from cache
+#[tokio::test]
+async fn test_prefetch_with_tags_serves_cached_value() {
+    let tag_key = "aws-sm-agent-prefetch-integ-test";
+    let secrets = TestSecrets::setup_tagged(tag_key).await;
+    let secret_type = SecretType::Tagged {
+        tag_key: tag_key.to_string(),
+    };
+    let secret_name = secrets.secret_name(&secret_type);
+
+    secrets
+        .wait_for_tag(&secret_type, tag_key)
+        .await
+        .expect("Timed out waiting for tag to propagate on secret");
+
+    let port = 2794;
+    let config_content = format!(
+        r#"
+http_port = {}
+log_level = "info"
+ttl_seconds = 300
+validate_credentials = true
+
+[prefetch]
+filter_tags = [
+  {{ key = "{}" }},
+]
+"#,
+        port, tag_key
+    );
+
+    let agent = AgentProcess::start_with_config_content(port, &config_content).await;
+
+    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
+    let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+    let client = aws_sdk_secretsmanager::Client::new(&config);
+
+    client
+        .update_secret()
+        .secret_id(&secret_name)
+        .secret_string(r#"{"username":"updateduser","password":"updatedpass"}"#)
+        .send()
+        .await
+        .expect("Failed to update secret");
+
+    let query = AgentQueryBuilder::default()
+        .secret_id(&secret_name)
+        .build()
+        .unwrap();
+
+    let response = agent.make_request(&query).await;
+    let json: serde_json::Value = serde_json::from_str(&response).unwrap();
+
+    assert!(
+        json["SecretString"].as_str().unwrap().contains("testuser"),
+        "Expected cached (old) value with 'testuser', got: {}",
+        json["SecretString"]
+    );
+}

--- a/integration-tests/tests/role_chaining.rs
+++ b/integration-tests/tests/role_chaining.rs
@@ -15,50 +15,12 @@ mod common;
 
 use common::*;
 
-const TARGET_ROLE_NAME: &str = "secrets-manager-agent";
-const NO_ACCESS_ROLE_NAME: &str = "secrets-manager-agent-no-access";
-
-struct RoleChainingHelper {
-    client: aws_sdk_sts::Client,
-    account_id: String,
-}
-
-impl RoleChainingHelper {
-    async fn new() -> Self {
-        let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
-        let client = aws_sdk_sts::Client::new(&config);
-        let account_id = client
-            .get_caller_identity()
-            .send()
-            .await
-            .expect("Failed to call GetCallerIdentity")
-            .account()
-            .expect("No account ID in response")
-            .to_string();
-        Self { client, account_id }
-    }
-
-    /// Pre-flight check: verify the role can be assumed, panic with a clear message if not.
-    /// Returns the full role ARN on success.
-    async fn get_role_arn(&self, role_name: &str) -> String {
-        let role_arn = format!("arn:aws:iam::{}:role/{role_name}", self.account_id);
-        self.client
-            .assume_role()
-            .role_arn(&role_arn)
-            .role_session_name("role-chaining-integration-tests")
-            .send()
-            .await
-            .unwrap_or_else(|e| panic!("Failed to assume role '{role_name}': {e}"));
-        role_arn
-    }
-}
-
 #[tokio::test]
 async fn test_role_chaining_basic_retrieval() {
     let helper = RoleChainingHelper::new().await;
     let role_arn = helper.get_role_arn(TARGET_ROLE_NAME).await;
     let secrets = TestSecrets::setup_basic().await;
-    let secret_name = secrets.secret_name(SecretType::Basic);
+    let secret_name = secrets.secret_name(&SecretType::Basic);
 
     let agent = AgentProcess::start().await;
 
@@ -116,7 +78,7 @@ async fn test_role_chaining_with_refresh_now() {
     let helper = RoleChainingHelper::new().await;
     let role_arn = helper.get_role_arn(TARGET_ROLE_NAME).await;
     let secrets = TestSecrets::setup_basic().await;
-    let secret_name = secrets.secret_name(SecretType::Basic);
+    let secret_name = secrets.secret_name(&SecretType::Basic);
 
     let agent = AgentProcess::start().await;
 
@@ -180,7 +142,7 @@ async fn test_role_chaining_no_access_role_denied() {
     let target_role_arn = helper.get_role_arn(TARGET_ROLE_NAME).await;
 
     let secrets = TestSecrets::setup_basic().await;
-    let secret_name = secrets.secret_name(SecretType::Basic);
+    let secret_name = secrets.secret_name(&SecretType::Basic);
 
     let agent = AgentProcess::start().await;
 
@@ -218,7 +180,7 @@ async fn test_role_chaining_separate_caches_per_role() {
     let role_arn = helper.get_role_arn(TARGET_ROLE_NAME).await;
 
     let secrets = TestSecrets::setup_basic().await;
-    let secret_name = secrets.secret_name(SecretType::Basic);
+    let secret_name = secrets.secret_name(&SecretType::Basic);
 
     let agent = AgentProcess::start().await;
 

--- a/integration-tests/tests/secret_retrieval.rs
+++ b/integration-tests/tests/secret_retrieval.rs
@@ -11,7 +11,7 @@ use common::*;
 #[tokio::test]
 async fn test_secret_retrieval_by_name() {
     let secrets = TestSecrets::setup_basic().await;
-    let secret_name = secrets.secret_name(SecretType::Basic);
+    let secret_name = secrets.secret_name(&SecretType::Basic);
 
     let agent = AgentProcess::start().await;
 
@@ -30,7 +30,7 @@ async fn test_secret_retrieval_by_name() {
 #[tokio::test]
 async fn test_secret_retrieval_by_arn() {
     let secrets = TestSecrets::setup_basic().await;
-    let secret_name = secrets.secret_name(SecretType::Basic);
+    let secret_name = secrets.secret_name(&SecretType::Basic);
 
     // Get the ARN using AWS SDK
     let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
@@ -58,7 +58,7 @@ async fn test_secret_retrieval_by_arn() {
 #[tokio::test]
 async fn test_binary_secret_retrieval() {
     let secrets = TestSecrets::setup_binary().await;
-    let secret_name = secrets.secret_name(SecretType::Binary);
+    let secret_name = secrets.secret_name(&SecretType::Binary);
 
     let agent = AgentProcess::start().await;
 
@@ -77,11 +77,11 @@ async fn test_binary_secret_retrieval() {
 #[tokio::test]
 async fn test_version_stage_retrieval() {
     let secrets = TestSecrets::setup_versioned().await;
-    let secret_name = secrets.secret_name(SecretType::Versioned);
+    let secret_name = secrets.secret_name(&SecretType::Versioned);
 
     // Wait for AWSPENDING version to be available
     let _ = secrets
-        .wait_for_pending_version(SecretType::Versioned)
+        .wait_for_pending_version(&SecretType::Versioned)
         .await;
 
     let agent = AgentProcess::start().await;
@@ -128,16 +128,16 @@ async fn test_version_stage_retrieval() {
 #[tokio::test]
 async fn test_version_id_retrieval() {
     let secrets = TestSecrets::setup_versioned().await;
-    let secret_name = secrets.secret_name(SecretType::Versioned);
+    let secret_name = secrets.secret_name(&SecretType::Versioned);
 
     // Wait for AWSPENDING version to be available
     let _ = secrets
-        .wait_for_pending_version(SecretType::Versioned)
+        .wait_for_pending_version(&SecretType::Versioned)
         .await;
 
     // Get the version IDs for both stages
     let (current_version_id, pending_version_id) =
-        secrets.get_version_ids(SecretType::Versioned).await;
+        secrets.get_version_ids(&SecretType::Versioned).await;
 
     let agent = AgentProcess::start().await;
 
@@ -177,7 +177,7 @@ async fn test_version_id_retrieval() {
 #[tokio::test]
 async fn test_large_secret_retrieval() {
     let secrets = TestSecrets::setup_large().await;
-    let secret_name = secrets.secret_name(SecretType::Large);
+    let secret_name = secrets.secret_name(&SecretType::Large);
 
     let agent = AgentProcess::start().await;
 

--- a/integration-tests/tests/security.rs
+++ b/integration-tests/tests/security.rs
@@ -11,7 +11,7 @@ use common::*;
 #[tokio::test]
 async fn test_ssrf_token_validation() {
     let secrets = TestSecrets::setup_basic().await;
-    let secret_name = secrets.secret_name(SecretType::Basic);
+    let secret_name = secrets.secret_name(&SecretType::Basic);
 
     let agent = AgentProcess::start().await;
 
@@ -55,7 +55,7 @@ async fn test_ssrf_token_validation() {
 #[tokio::test]
 async fn test_x_forwarded_for_rejection() {
     let secrets = TestSecrets::setup_basic().await;
-    let secret_name = secrets.secret_name(SecretType::Basic);
+    let secret_name = secrets.secret_name(&SecretType::Basic);
 
     let agent = AgentProcess::start().await;
 

--- a/integration-tests/tests/version_management.rs
+++ b/integration-tests/tests/version_management.rs
@@ -11,18 +11,18 @@ use common::*;
 #[tokio::test]
 async fn test_version_stage_transitions() {
     let secrets = TestSecrets::setup_versioned().await;
-    let secret_name = secrets.secret_name(SecretType::Versioned);
+    let secret_name = secrets.secret_name(&SecretType::Versioned);
 
     let agent = AgentProcess::start().await;
 
     // Wait for AWSPENDING version to be available
     let _ = secrets
-        .wait_for_pending_version(SecretType::Versioned)
+        .wait_for_pending_version(&SecretType::Versioned)
         .await;
 
     // Get the version IDs for both stages
     let (current_version_id, pending_version_id) =
-        secrets.get_version_ids(SecretType::Versioned).await;
+        secrets.get_version_ids(&SecretType::Versioned).await;
 
     // Test AWSPENDING stage before promotion
     let pending_query = AgentQueryBuilder::default()


### PR DESCRIPTION
## Description

### Why is this change being made?

1. Add pre-fetching support for warming the secret cache at startup


### What is changing?

1.  Pre-fetch secrets at startup — supports explicit secret IDs and tag-based discovery, with optional cross-account access via role chaining and configurable jitter to avoid fleet-wide API spikes
2.  Integration tests — covers explicit secrets, tag-based discovery, inline TOML config, cross-account pre-fetching, and resilience to nonexistent secrets
3.  Documentation — README sections for pre-fetching configuration, role eviction behavior, and IAM role setup required for integration tests


### Related Links
- **Issue #, if available**:

---

## Testing

### How was this tested?

1. Added unit tests and integration tests for the feature

### When testing locally, provide testing artifact(s):

1. Unit tests:
```
cargo test --workspace --exclude integration-tests -- --test-threads=1 2>&1 | grep -E "(error\[|FAILED|test result)" | head -10
test result: ok. 128 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 33.09s
test result: ok. 33 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.48s
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 6.30s
```

4. Integration tests:
```
running 5 tests
test test_prefetch_inline_syntax_serves_cached_value ... ok
test test_prefetch_nonexistent_secret_doesnt_crash ... ok
test test_prefetch_serves_cached_value ... ok
test test_prefetch_with_role_chaining_serves_cached_value ... ok
test test_prefetch_with_tags_serves_cached_value ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 21.33s
```

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x ] I have reviewed, tested and understand all changes
  *If not, why:*
- [X ] I have filled out the Description and Testing sections above
  *If not, why:*
- [X ] Build and Unit tests are passing
  *If not, why:*
- [X ] Unit test coverage check is passing
  *If not, why:*
- [X ] Integration tests pass locally
  *If not, why:*
- [X ] I have updated integration tests (if needed)
  *If not, why:*
- [X ] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [X ] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [X ] I have updated README/documentation (if needed)
  *If not, why:*
- [X ] I have clearly called out breaking changes (if any)
  *If not, why:*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
