### PR TITLE
fix: Shorten Linux user/group names

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can provide a custom configuration by passing `--config /path/to/config.toml
 
 For full configuration details, see [Configure the Workload Credentials Provider](#workload-credentials-provider-config)\.
 
-To download the source code, see [https://github\.com/aws/aws\-secretsmanager\-agent](https://github.com/aws/aws-secretsmanager-agent) on GitHub\.
+To download the source code, see [https://github\.com/aws/aws\-workload\-credentials\-provider](https://github.com/aws/aws-workload-credentials-provider) on GitHub\.
 
 **Topics**
 - [AWS Workload Credentials Provider](#aws-workload-credentials-provider)
@@ -73,9 +73,9 @@ To build the Workload Credentials Provider binary natively, you need the standar
 
 ------
 
-**NOTE:** To ensure a stable experience, use a specific git tag when building from source code. You can find a list of version tags [here](https://github.com/aws/aws-secretsmanager-agent/tags). Tags are in the pattern `/v\d+\.\d+\.\d+/` and follow [SemVer 2.0.0](https://semver.org/spec/v2.0.0.html).
+**NOTE:** To ensure a stable experience, use a specific git tag when building from source code. You can find a list of version tags [here](https://github.com/aws/aws-workload-credentials-provider/tags). Tags are in the pattern `/v\d+\.\d+\.\d+/` and follow [SemVer 2.0.0](https://semver.org/spec/v2.0.0.html).
 
-Example: `git clone --branch <git tag> https://github.com/aws/aws-secretsmanager-agent.git`
+Example: `git clone --branch <git tag> https://github.com/aws/aws-workload-credentials-provider.git`
 
 **NOTE:** Building the provider with the `fips` feature enabled on macOS currently requires the following workaround:
 
@@ -186,12 +186,12 @@ Based on the type of compute, you have several options for installing the Worklo
    - `--no-privileges` — (Optional) Skip Linux capabilities on ACM service
    - `--no-sudoers` — (Optional) Skip sudoers generation
 
-   The script generates a random SSRF token on startup and stores it in the file `/var/run/awssmatoken`\. The token is readable by the `aws-workload-credentials-provider-token` group that the install script creates\. 
+   The script generates a random SSRF token on startup and stores it in the file `/var/run/awssmatoken`\. The token is readable by the `aws-wcp-token` group that the install script creates\. 
 
-1. To allow your application to read the token file, you need to add the user account that your application runs under to the `aws-workload-credentials-provider-token` group\. For example, you can grant permissions for your application to read the token file with the following usermod command, where *<APP\_USER>* is the user ID under which your application runs\.
+1. To allow your application to read the token file, you need to add the user account that your application runs under to the `aws-wcp-token` group\. For example, you can grant permissions for your application to read the token file with the following usermod command, where *<APP\_USER>* is the user ID under which your application runs\.
 
    ```sh
-   sudo usermod -aG aws-workload-credentials-provider-token <APP_USER>
+   sudo usermod -aG aws-wcp-token <APP_USER>
    ```
 
 ------
@@ -297,7 +297,7 @@ You can [package the Workload Credentials Provider as an AWS Lambda extension](h
 
 **Note:** The Certificate Management capability is not supported on AWS Lambda\.
 
-The following instructions show how to get a secret named *MyTest* by using the example script `secrets-manager-provider-extension.sh` in [https://github\.com/aws/aws\-secretsmanager\-agent](https://github.com/aws/aws-secretsmanager-agent) to install the Workload Credentials Provider as a Lambda extension\.
+The following instructions show how to get a secret named *MyTest* by using the example script `secrets-manager-provider-extension.sh` in [https://github\.com/aws/aws\-workload\-credentials\-provider](https://github.com/aws/aws-workload-credentials-provider) to install the Workload Credentials Provider as a Lambda extension\.
 
 **To create a Lambda extension that packages the Workload Credentials Provider**
 

--- a/aws_workload_credentials_provider_common/configuration/aws-workload-credentials-provider-acm-nocaps.service
+++ b/aws_workload_credentials_provider_common/configuration/aws-workload-credentials-provider-acm-nocaps.service
@@ -4,7 +4,7 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-User=aws-workload-credentials-provider
+User=aws-wcp
 WorkingDirectory=/opt/aws/workload-credentials-provider
 Type=simple
 Restart=on-failure

--- a/aws_workload_credentials_provider_common/configuration/aws-workload-credentials-provider-acm.service
+++ b/aws_workload_credentials_provider_common/configuration/aws-workload-credentials-provider-acm.service
@@ -4,7 +4,7 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-User=aws-workload-credentials-provider
+User=aws-wcp
 WorkingDirectory=/opt/aws/workload-credentials-provider
 Type=simple
 Restart=on-failure

--- a/aws_workload_credentials_provider_common/configuration/aws-workload-credentials-provider-sm.service
+++ b/aws_workload_credentials_provider_common/configuration/aws-workload-credentials-provider-sm.service
@@ -6,7 +6,7 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-User=aws-workload-credentials-provider
+User=aws-wcp
 WorkingDirectory=/opt/aws/workload-credentials-provider
 Environment="AWS_TOKEN=file:///var/run/awssmatoken"
 Type=simple

--- a/aws_workload_credentials_provider_common/configuration/aws-workload-credentials-provider-token
+++ b/aws_workload_credentials_provider_common/configuration/aws-workload-credentials-provider-token
@@ -2,7 +2,7 @@
 
 PATH=/bin:/usr/bin:/sbin:/usr/sbin
 TOKENFILE=/var/run/awssmatoken
-TOKENGROUP=aws-workload-credentials-provider-token
+TOKENGROUP=aws-wcp-token
 case "$1" in
     start)
         echo -e "Initializing SSRF token"

--- a/aws_workload_credentials_provider_common/configuration/common.sh
+++ b/aws_workload_credentials_provider_common/configuration/common.sh
@@ -5,8 +5,8 @@ CONFIG_DIR=/etc/aws-workload-credentials-provider
 SYSTEMD_FILES=/etc/systemd/system
 
 PROVIDER_GROUP=awscreds
-TOKEN_GROUP=aws-workload-credentials-provider-token
-PROVIDER_USER=aws-workload-credentials-provider
+TOKEN_GROUP=aws-wcp-token
+PROVIDER_USER=aws-wcp
 
 TOKEN_SCRIPT=aws-workload-credentials-provider-token
 SM_SERVICE=aws-workload-credentials-provider-sm

--- a/aws_workload_credentials_provider_common/src/constants.rs
+++ b/aws_workload_credentials_provider_common/src/constants.rs
@@ -4,7 +4,7 @@
 pub const PROVIDER_NAME: &str = "aws-workload-credentials-provider";
 
 /// System user the provider runs as.
-pub const PROVIDER_USER: &str = "aws-workload-credentials-provider";
+pub const PROVIDER_USER: &str = "aws-wcp";
 
 /// Primary group for provider-created files.
 pub const PROVIDER_GROUP: &str = "awscreds";


### PR DESCRIPTION
## Description

### Why is this change being made?

1. Linux enforces a 32-character limit on user and group names. Shorten it.


### What is changing?

1. Shortened Linux user name: `aws-workload-credentials-provider` → `aws-wcp`
2. Shortened token group name: `aws-workload-credentials-provider-token` → `aws-wcp-token`
3. Updated systemd service files, token script, common.sh, and constants.rs with new names
4. Updated README refs from `aws/aws-secretsmanager-agent` to `aws/aws-workload-credentials-provider`


### Related Links
- **Issue #, if available**:

---

## Testing

### How was this tested?

1. tested on linux machine

### When testing locally, provide testing artifact(s):

1. N/A

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [x] Build and Unit tests are passing
  *If not, why:*
- [x] Unit test coverage check is passing
  *If not, why:*
- [x] Integration tests pass locally
  *If not, why:*
- [x] I have updated integration tests (if needed)
  *If not, why:*
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [x] I have updated README/documentation (if needed)
  *If not, why:*
- [x] I have clearly called out breaking changes (if any)
  *If not, why:*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
