### PR TITLE
Use updated integ test role names

### DIFF
--- a/README.md
+++ b/README.md
@@ -867,9 +867,9 @@ Your AWS credentials must have the following permissions:
 
 The role chaining integration tests require two IAM roles in the same account:
 
-1. **`secrets-manager-agent`** — Must be assumable by the test runner's identity and have `secretsmanager:GetSecretValue` and `secretsmanager:DescribeSecret` permissions.
+1. **`asm-role-chaining-role`** — Must be assumable by the test runner's identity and have `secretsmanager:GetSecretValue` and `secretsmanager:DescribeSecret` permissions.
 
-2. **`secrets-manager-agent-no-access`** — Must be assumable by the test runner's identity but have *no* Secrets Manager permissions. Used to verify access-denied behavior.
+2. **`provider-no-access-role`** — Must be assumable by the test runner's identity but have *no* Secrets Manager permissions. Used to verify access-denied behavior.
 
 Both roles must have a trust policy that allows the identity running the tests to call `sts:AssumeRole`. The account ID is discovered automatically via `sts:GetCallerIdentity`.
 


### PR DESCRIPTION
## Description

### Why is this change being made?

The README still uses the old role names `secrets-manager-agent` and `secrets-manager-agent-no-access` in the integ test section. These were updated to `asm-role-chaining-role` and `provider-no-access-role` as part of the rename.

Ref https://github.com/aws/aws-workload-credentials-provider/blob/main/integration-tests/tests/common.rs#L574-L576

### What is changing?

Updated role names in README


### Related Links
- **Issue #, if available**: n/a

---

## Testing

### How was this tested?

1. Ran integ tests with the new role names, tests pass (fail with old role names).

### When testing locally, provide testing artifact(s):

1. n/a

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [x] Build and Unit tests are passing
  *If not, why:*
- [x] Unit test coverage check is passing
  *If not, why:*
- [x] Integration tests pass locally
  *If not, why:*
- [ ] I have updated integration tests (if needed)
  *If not, why:* N/A
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [ ] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:* N/A
- [x] I have updated README/documentation (if needed)
  *If not, why:*
- [ ] I have clearly called out breaking changes (if any)
  *If not, why:* None

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
