### PR TITLE
Add file-based credential provider with session token gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,7 +708,10 @@ dependencies = [
 name = "aws_secretsmanager_provider"
 version = "3.0.0"
 dependencies = [
+ "arc-swap",
  "aws-config",
+ "aws-credential-types",
+ "aws-runtime",
  "aws-sdk-secretsmanager",
  "aws-sdk-sts",
  "aws-smithy-runtime",
@@ -728,6 +731,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-util",
  "url",
@@ -2164,6 +2168,7 @@ name = "integration-tests"
 version = "0.1.0"
 dependencies = [
  "aws-config",
+ "aws-credential-types",
  "aws-sdk-secretsmanager",
  "aws-sdk-sts",
  "aws_certificatemanager_provider",

--- a/README.md
+++ b/README.md
@@ -826,7 +826,6 @@ aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 aws_session_token = IQoJb3JpZ2luX2Vj...
 ```
 
-
 **Important:** The provider enforces a session token gate — credentials without an `aws_session_token` are rejected\. This prevents use of long\-term IAM User credentials\. IAM Roles Anywhere credentials always include a session token\.
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -826,7 +826,7 @@ aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 aws_session_token = IQoJb3JpZ2luX2Vj...
 ```
 
-**Important:** The provider enforces a session token gate — credentials without an `aws_session_token` are rejected\. This prevents use of long\-term IAM User credentials\. IAM Roles Anywhere credentials always include a session token, so legitimate use cases are unaffected\.
+**Important:** The provider enforces a session token gate — credentials without an `aws_session_token` are rejected\. This prevents use of long\-term IAM User credentials\. IAM Roles Anywhere credentials always include a session token\.
 
 ### Configuration
 
@@ -866,72 +866,7 @@ The provider is designed to start successfully regardless of the credentials fil
 
 ### Security
 
-The session token gate ensures that only temporary credentials can be used via the file path\. This is strictly more restrictive than the existing default SDK credential chain, which already accepts static credentials via environment variables without validation\.
-
-On Unix systems, the provider logs a warning if the credentials file has permissions more permissive than owner\-only \(`0600`\)\. Consider restricting file permissions:
-
-```sh
-chmod 600 /path/to/credentials
-```
-
-## File-based credentials
-
-By default, the Workload Credentials Provider uses the [AWS SDK default credential provider chain](https://docs.aws.amazon.com/sdk-for-rust/latest/dg/credproviders.html) to authenticate with Secrets Manager\. This works well on Amazon EC2 \(via IMDS\), Lambda, and ECS/EKS \(via container credentials\)\.
-
-For environments where credentials are delivered to the filesystem — such as on\-premises or multicloud hosts using [IAM Roles Anywhere](https://docs.aws.amazon.com/rolesanywhere/latest/userguide/introduction.html) — you can configure the provider to read credentials from a file\. The IAM Roles Anywhere credential helper's `update` command writes rotating temporary credentials to the standard AWS credentials file, and the provider automatically picks up refreshed credentials without requiring a restart\.
-
-### Credentials file format
-
-The credentials file must use the standard AWS credentials file format and must include a session token \(temporary credentials\):
-
-```
-[default]
-aws_access_key_id = AKIAIOSFODNN7EXAMPLE
-aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-aws_session_token = IQoJb3JpZ2luX2Vj...
-```
-
-**Important:** The provider enforces a session token gate — credentials without an `aws_session_token` are rejected\. This prevents use of long\-term IAM User credentials\. IAM Roles Anywhere credentials always include a session token, so legitimate use cases are unaffected\.
-
-### Configuration
-
-Set the `credentials_file_path` parameter in your configuration file:
-
-```toml
-[capabilities.secrets_manager]
-region = "us-east-1"
-credentials_file_path = "/path/to/credentials"
-```
-
-Or in the legacy flat format:
-
-```toml
-region = "us-east-1"
-credentials_file_path = "/path/to/credentials"
-```
-
-### Credential refresh behavior
-
-The provider automatically detects and re\-reads updated credentials from the file:
-
-+ The provider checks the credentials file for changes every 5 minutes\.
-+ When the file's modification time changes, the provider reloads the credentials\.
-+ After every load or reload, the provider validates that `aws_session_token` is present\. If absent, the credentials are rejected and previously cached valid credentials are retained\.
-+ If the file is missing or malformed during a reload, the provider continues using the previously cached credentials and retries on the next cycle\.
-+ Credentials are served to the AWS SDK with a 10\-minute expiry window, ensuring the SDK periodically requests fresh credentials from the provider\.
-
-### Startup behavior
-
-The provider is designed to start successfully regardless of the credentials file state:
-
-+ If the file exists and contains valid temporary credentials, the provider loads them immediately\.
-+ If the file is missing, empty, or malformed, the provider starts without credentials and the background reload task will pick up valid credentials when they appear\.
-+ When file\-based credentials are configured, the provider skips the STS credential validation check at startup, since the credentials file may not yet exist\.
-+ Calls to Secrets Manager will fail until valid credentials are available\. The provider process itself remains running and will begin serving requests once credentials appear in the file\.
-
-### Security
-
-The session token gate ensures that only temporary credentials can be used via the file path\. This is strictly more restrictive than the existing default SDK credential chain, which already accepts static credentials via environment variables without validation\.
+The session token gate ensures that only temporary credentials can be used via the file path\.
 
 On Unix systems, the provider logs a warning if the credentials file has permissions more permissive than owner\-only \(`0600`\)\. Consider restricting file permissions:
 

--- a/README.md
+++ b/README.md
@@ -817,7 +817,7 @@ For environments where credentials are delivered to the filesystem — such as o
 
 ### Credentials file format
 
-The credentials file must use the standard AWS credentials file format and must include a session token \(temporary credentials\):
+The credentials file must use the standard AWS credentials file format with a `[default]` profile and must include a session token \(temporary credentials\):
 
 ```
 [default]
@@ -825,6 +825,7 @@ aws_access_key_id = AKIAIOSFODNN7EXAMPLE
 aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 aws_session_token = IQoJb3JpZ2luX2Vj...
 ```
+
 
 **Important:** The provider enforces a session token gate — credentials without an `aws_session_token` are rejected\. This prevents use of long\-term IAM User credentials\. IAM Roles Anywhere credentials always include a session token\.
 

--- a/README.md
+++ b/README.md
@@ -732,6 +732,7 @@ secrets = [
 + **cache\_size** – The maximum number of secrets that can be stored in the cache, in the range 1 to 1000\. The default is 1000\.
 + **ssrf\_headers** – A list of header names the Workload Credentials Provider checks for the SSRF token\. The default is "X\-Aws\-Parameters\-Secrets\-Token, X\-Vault\-Token"\.
 + **ssrf\_env\_variables** – A list of environment variable names the Workload Credentials Provider checks in sequential order for the SSRF token\. The environment variable can contain the token or a reference to the token file as in: `AWS_TOKEN=file:///var/run/awssmatoken`\. The default is "AWS\_TOKEN, AWS\_SESSION\_TOKEN, AWS\_CONTAINER\_AUTHORIZATION\_TOKEN"\.
++ **credentials\_file\_path** – The path to a file containing AWS credentials in the standard AWS credentials file format\. When set, the provider reads credentials from this file instead of using the default SDK credential provider chain\. The provider automatically reloads credentials when the file changes, making it compatible with credential rotation systems such as [IAM Roles Anywhere](https://docs.aws.amazon.com/rolesanywhere/latest/userguide/introduction.html) that deliver refreshed credentials to the filesystem\. This parameter is optional\.
 
 ### Certificate Management configuration
 
@@ -807,6 +808,136 @@ sudo ./aws-workload-credentials-provider acm reload --config /path/to/config.tom
 .\aws-workload-credentials-provider.exe acm reload --Config C:\path\to\config.toml
 ```
 
+
+## File-based credentials
+
+By default, the Workload Credentials Provider uses the [AWS SDK default credential provider chain](https://docs.aws.amazon.com/sdk-for-rust/latest/dg/credproviders.html) to authenticate with Secrets Manager\. This works well on Amazon EC2 \(via IMDS\), Lambda, and ECS/EKS \(via container credentials\)\.
+
+For environments where credentials are delivered to the filesystem — such as on\-premises or multicloud hosts using [IAM Roles Anywhere](https://docs.aws.amazon.com/rolesanywhere/latest/userguide/introduction.html) — you can configure the provider to read credentials from a file\. The IAM Roles Anywhere credential helper's `update` command writes rotating temporary credentials to the standard AWS credentials file, and the provider automatically picks up refreshed credentials without requiring a restart\.
+
+### Credentials file format
+
+The credentials file must use the standard AWS credentials file format and must include a session token \(temporary credentials\):
+
+```
+[default]
+aws_access_key_id = AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+aws_session_token = IQoJb3JpZ2luX2Vj...
+```
+
+**Important:** The provider enforces a session token gate — credentials without an `aws_session_token` are rejected\. This prevents use of long\-term IAM User credentials\. IAM Roles Anywhere credentials always include a session token, so legitimate use cases are unaffected\.
+
+### Configuration
+
+Set the `credentials_file_path` parameter in your configuration file:
+
+```toml
+[capabilities.secrets_manager]
+region = "us-east-1"
+credentials_file_path = "/path/to/credentials"
+```
+
+Or in the legacy flat format:
+
+```toml
+region = "us-east-1"
+credentials_file_path = "/path/to/credentials"
+```
+
+### Credential refresh behavior
+
+The provider automatically detects and re\-reads updated credentials from the file:
+
++ The provider checks the credentials file for changes every 5 minutes\.
++ When the file's modification time changes, the provider reloads the credentials\.
++ After every load or reload, the provider validates that `aws_session_token` is present\. If absent, the credentials are rejected and previously cached valid credentials are retained\.
++ If the file is missing or malformed during a reload, the provider continues using the previously cached credentials and retries on the next cycle\.
++ Credentials are served to the AWS SDK with a 10\-minute expiry window, ensuring the SDK periodically requests fresh credentials from the provider\.
+
+### Startup behavior
+
+The provider is designed to start successfully regardless of the credentials file state:
+
++ If the file exists and contains valid temporary credentials, the provider loads them immediately\.
++ If the file is missing, empty, or malformed, the provider starts without credentials and the background reload task will pick up valid credentials when they appear\.
++ When file\-based credentials are configured, the provider skips the STS credential validation check at startup, since the credentials file may not yet exist\.
++ Calls to Secrets Manager will fail until valid credentials are available\. The provider process itself remains running and will begin serving requests once credentials appear in the file\.
+
+### Security
+
+The session token gate ensures that only temporary credentials can be used via the file path\. This is strictly more restrictive than the existing default SDK credential chain, which already accepts static credentials via environment variables without validation\.
+
+On Unix systems, the provider logs a warning if the credentials file has permissions more permissive than owner\-only \(`0600`\)\. Consider restricting file permissions:
+
+```sh
+chmod 600 /path/to/credentials
+```
+
+## File-based credentials
+
+By default, the Workload Credentials Provider uses the [AWS SDK default credential provider chain](https://docs.aws.amazon.com/sdk-for-rust/latest/dg/credproviders.html) to authenticate with Secrets Manager\. This works well on Amazon EC2 \(via IMDS\), Lambda, and ECS/EKS \(via container credentials\)\.
+
+For environments where credentials are delivered to the filesystem — such as on\-premises or multicloud hosts using [IAM Roles Anywhere](https://docs.aws.amazon.com/rolesanywhere/latest/userguide/introduction.html) — you can configure the provider to read credentials from a file\. The IAM Roles Anywhere credential helper's `update` command writes rotating temporary credentials to the standard AWS credentials file, and the provider automatically picks up refreshed credentials without requiring a restart\.
+
+### Credentials file format
+
+The credentials file must use the standard AWS credentials file format and must include a session token \(temporary credentials\):
+
+```
+[default]
+aws_access_key_id = AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+aws_session_token = IQoJb3JpZ2luX2Vj...
+```
+
+**Important:** The provider enforces a session token gate — credentials without an `aws_session_token` are rejected\. This prevents use of long\-term IAM User credentials\. IAM Roles Anywhere credentials always include a session token, so legitimate use cases are unaffected\.
+
+### Configuration
+
+Set the `credentials_file_path` parameter in your configuration file:
+
+```toml
+[capabilities.secrets_manager]
+region = "us-east-1"
+credentials_file_path = "/path/to/credentials"
+```
+
+Or in the legacy flat format:
+
+```toml
+region = "us-east-1"
+credentials_file_path = "/path/to/credentials"
+```
+
+### Credential refresh behavior
+
+The provider automatically detects and re\-reads updated credentials from the file:
+
++ The provider checks the credentials file for changes every 5 minutes\.
++ When the file's modification time changes, the provider reloads the credentials\.
++ After every load or reload, the provider validates that `aws_session_token` is present\. If absent, the credentials are rejected and previously cached valid credentials are retained\.
++ If the file is missing or malformed during a reload, the provider continues using the previously cached credentials and retries on the next cycle\.
++ Credentials are served to the AWS SDK with a 10\-minute expiry window, ensuring the SDK periodically requests fresh credentials from the provider\.
+
+### Startup behavior
+
+The provider is designed to start successfully regardless of the credentials file state:
+
++ If the file exists and contains valid temporary credentials, the provider loads them immediately\.
++ If the file is missing, empty, or malformed, the provider starts without credentials and the background reload task will pick up valid credentials when they appear\.
++ When file\-based credentials are configured, the provider skips the STS credential validation check at startup, since the credentials file may not yet exist\.
++ Calls to Secrets Manager will fail until valid credentials are available\. The provider process itself remains running and will begin serving requests once credentials appear in the file\.
+
+### Security
+
+The session token gate ensures that only temporary credentials can be used via the file path\. This is strictly more restrictive than the existing default SDK credential chain, which already accepts static credentials via environment variables without validation\.
+
+On Unix systems, the provider logs a warning if the credentials file has permissions more permissive than owner\-only \(`0600`\)\. Consider restricting file permissions:
+
+```sh
+chmod 600 /path/to/credentials
+```
 
 ## Optional features<a name="workload-credentials-provider-features"></a>
 
@@ -911,3 +1042,4 @@ The integration tests are organized into the following modules:
 - **`role_chaining.rs`** - Tests cross\-account secret retrieval via IAM role assumption, including invalid role ARN handling, access denied scenarios, refreshNow with role chaining, and separate per\-role cache isolation
 - **`prefetch.rs`** - Tests pre\-fetching secrets into the cache at startup, including explicit secrets, tag\-based discovery, inline TOML syntax, cross\-account pre\-fetching via role chaining, and resilience to nonexistent secrets
 - **`certificate_provider.rs`** - Tests the Certificate Management capability including certificate export, file writing, fullchain mode, refresh command execution, and file permission configuration
+- **`file_credentials.rs`** - Tests file\-based credential loading including valid/invalid/missing credentials, session token gate enforcement, self\-healing \(credentials appearing after startup\), and credential rotation

--- a/aws_secretsmanager_provider/Cargo.toml
+++ b/aws_secretsmanager_provider/Cargo.toml
@@ -27,9 +27,12 @@ serde_json = "1"
 serde_derive = "1"
 
 aws-config = "1"
+aws-credential-types = "1"
+aws-runtime = "1"
 aws-sdk-secretsmanager = "1"
 aws-smithy-runtime-api = "1"
 aws-sdk-sts = "1"
+arc-swap = "1"
 log = "0.4.29"
 log4rs = { version = "1.2.0", features = ["gzip"] }
 tokio-util = "0.7.18"
@@ -47,3 +50,4 @@ aws_secretsmanager_caching = { version = "2.1.0", path = "../aws_secretsmanager_
 tokio = { version = "1", features = ["test-util", "rt-multi-thread", "net", "macros"] }
 http = "0.2.9"
 aws-smithy-types = "1"
+tempfile = "3"

--- a/aws_secretsmanager_provider/src/cache_manager.rs
+++ b/aws_secretsmanager_provider/src/cache_manager.rs
@@ -43,8 +43,9 @@ use crate::utils::create_role_asm_client;
 impl CacheManager {
     /// Create a new CacheManager.
     pub async fn new(cfg: &SecretsManagerConfig) -> Result<Self, Box<dyn std::error::Error>> {
+        let (client, sdk_config) = asm_client(cfg).await?;
         let default_client = Arc::new(SecretsManagerCachingClient::new(
-            asm_client(cfg).await?,
+            client,
             cfg.cache.cache_size,
             Duration::from_secs(cfg.cache.ttl_seconds as u64),
             cfg.ignore_transient_errors,
@@ -55,7 +56,7 @@ impl CacheManager {
             role_clients: RwLock::new(HashMap::new()),
             config: cfg.clone(),
             #[cfg(not(test))]
-            base_sdk_config: aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await,
+            base_sdk_config: sdk_config,
         })
     }
 
@@ -268,8 +269,9 @@ impl CacheManager {
         &self,
         _role_arn: &str,
     ) -> Result<SecretsManagerCachingClient, Box<dyn std::error::Error>> {
+        let (client, _) = asm_client(&self.config).await?;
         Ok(SecretsManagerCachingClient::new(
-            asm_client(&self.config).await?,
+            client,
             self.config.cache.cache_size,
             Duration::from_secs(self.config.cache.ttl_seconds as u64),
             self.config.ignore_transient_errors,
@@ -424,8 +426,8 @@ pub mod tests {
     // Used to replace the real client with the stub client.
     pub async fn init_client(
         _cfg: &SecretsManagerConfig,
-    ) -> Result<secretsmanager::Client, Box<dyn std::error::Error>> {
-        Ok(CLIENT.with_borrow(|v| v.clone()))
+    ) -> Result<(secretsmanager::Client, ()), Box<dyn std::error::Error>> {
+        Ok((CLIENT.with_borrow(|v| v.clone()), ()))
     }
 
     // Private helper to look at the request and provide the correct response.

--- a/aws_secretsmanager_provider/src/credentials_file_provider.rs
+++ b/aws_secretsmanager_provider/src/credentials_file_provider.rs
@@ -53,10 +53,10 @@ impl FileBasedCredentialsProvider {
         let path = path.into();
         let cached = Arc::new(ArcSwapOption::new(None));
 
-        match CredentialsLoader::new(&path).load_and_validate().await {
+        match Self::load_and_validate(&path).await {
             Ok(creds) => {
                 cached.store(Some(Arc::new(creds)));
-                warn_if_broad_permissions(&path);
+                Self::warn_if_broad_permissions(&path);
                 log::info!("Loaded file-based credentials from: {}", path.display());
             }
             Err(e) => {
@@ -72,22 +72,22 @@ impl FileBasedCredentialsProvider {
 
         let reload_cached = cached.clone();
         let handle = tokio::spawn(async move {
-            let mut last_modified = file_modified_time(&path);
+            let mut last_modified = Self::file_modified_time(&path);
             let mut interval = tokio::time::interval(reload_delay());
             interval.tick().await; // skip immediate first tick
             loop {
                 interval.tick().await;
 
-                let current_modified = file_modified_time(&path);
+                let current_modified = Self::file_modified_time(&path);
                 if current_modified == last_modified {
                     continue;
                 }
 
-                match CredentialsLoader::new(&path).load_and_validate().await {
+                match Self::load_and_validate(&path).await {
                     Ok(creds) => {
                         reload_cached.store(Some(Arc::new(creds)));
                         last_modified = current_modified;
-                        warn_if_broad_permissions(&path);
+                        Self::warn_if_broad_permissions(&path);
                         log::debug!("Successfully reloaded credentials from {}", path.display());
                     }
                     Err(e) => {
@@ -106,35 +106,17 @@ impl FileBasedCredentialsProvider {
             _reload_handle: Arc::new(ReloadHandle(handle)),
         }
     }
-}
 
-impl ProvideCredentials for FileBasedCredentialsProvider {
-    fn provide_credentials<'a>(&'a self) -> future::ProvideCredentials<'a>
-    where
-        Self: 'a,
-    {
-        future::ProvideCredentials::new(async {
-            self.cached
-                .load()
-                .as_ref()
-                .map(|c| with_expiry((**c).clone()))
-                .ok_or_else(|| CredentialsError::not_loaded("No credentials available"))
-        })
-    }
-}
+    async fn load_and_validate<P: Into<PathBuf>>(path: P) -> Result<Credentials, CredentialsError> {
+        let env_config_files = EnvConfigFiles::builder()
+            .with_file(EnvConfigFileKind::Credentials, path)
+            .build();
 
-struct CredentialsLoader<'a> {
-    path: &'a Path,
-}
-
-impl<'a> CredentialsLoader<'a> {
-    fn new(path: &'a Path) -> Self {
-        Self { path }
-    }
-
-    /// Parse credentials from the file and validate they contain a session token.
-    async fn load_and_validate(&self) -> Result<Credentials, CredentialsError> {
-        let creds = self.load_from_file().await?;
+        let creds = ProfileFileCredentialsProvider::builder()
+            .profile_files(env_config_files)
+            .build()
+            .provide_credentials()
+            .await?;
 
         if creds.session_token().is_none() {
             return Err(CredentialsError::provider_error(
@@ -146,53 +128,55 @@ impl<'a> CredentialsLoader<'a> {
         Ok(creds)
     }
 
-    /// Parse credentials from the file using the AWS SDK's profile file parser.
-    async fn load_from_file(&self) -> Result<Credentials, CredentialsError> {
-        let env_config_files = EnvConfigFiles::builder()
-            .with_file(EnvConfigFileKind::Credentials, self.path)
-            .build();
-
-        ProfileFileCredentialsProvider::builder()
-            .profile_files(env_config_files)
-            .build()
-            .provide_credentials()
-            .await
+    /// Wrap credentials with an SDK expiry so the SDK knows when to ask again.
+    fn with_expiry(creds: Credentials) -> Credentials {
+        Credentials::new(
+            creds.access_key_id(),
+            creds.secret_access_key(),
+            creds.session_token().map(|s| s.to_string()),
+            Some(SystemTime::now() + SDK_CREDENTIALS_TTL),
+            "FileBasedCredentialsProvider",
+        )
     }
-}
 
-/// Wrap credentials with an SDK expiry so the SDK knows when to ask again.
-fn with_expiry(creds: Credentials) -> Credentials {
-    Credentials::new(
-        creds.access_key_id(),
-        creds.secret_access_key(),
-        creds.session_token().map(|s| s.to_string()),
-        Some(SystemTime::now() + SDK_CREDENTIALS_TTL),
-        "FileBasedCredentialsProvider",
-    )
-}
+    fn file_modified_time(path: &Path) -> Option<SystemTime> {
+        std::fs::metadata(path).and_then(|m| m.modified()).ok()
+    }
 
-fn file_modified_time(path: &Path) -> Option<SystemTime> {
-    std::fs::metadata(path).and_then(|m| m.modified()).ok()
-}
-
-#[cfg(unix)]
-fn warn_if_broad_permissions(path: &Path) {
-    use std::os::unix::fs::PermissionsExt;
-    if let Ok(metadata) = std::fs::metadata(path) {
-        let mode = metadata.permissions().mode();
-        if mode & 0o077 != 0 {
-            log::warn!(
-                "Credentials file {} has broad permissions ({:o}). \
+    #[cfg(unix)]
+    fn warn_if_broad_permissions(path: &Path) {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(metadata) = std::fs::metadata(path) {
+            let mode = metadata.permissions().mode();
+            if mode & 0o077 != 0 {
+                log::warn!(
+                    "Credentials file {} has broad permissions ({:o}). \
                  Consider restricting to owner-only (chmod 600).",
-                path.display(),
-                mode & 0o777
-            );
+                    path.display(),
+                    mode & 0o777
+                );
+            }
         }
     }
+
+    #[cfg(not(unix))]
+    fn warn_if_broad_permissions(_path: &Path) {}
 }
 
-#[cfg(not(unix))]
-fn warn_if_broad_permissions(_path: &Path) {}
+impl ProvideCredentials for FileBasedCredentialsProvider {
+    fn provide_credentials<'a>(&'a self) -> future::ProvideCredentials<'a>
+    where
+        Self: 'a,
+    {
+        future::ProvideCredentials::new(async {
+            self.cached
+                .load()
+                .as_ref()
+                .map(|c| Self::with_expiry((**c).clone()))
+                .ok_or_else(|| CredentialsError::not_loaded("No credentials available"))
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/aws_secretsmanager_provider/src/credentials_file_provider.rs
+++ b/aws_secretsmanager_provider/src/credentials_file_provider.rs
@@ -1,0 +1,318 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use arc_swap::ArcSwapOption;
+use aws_config::profile::ProfileFileCredentialsProvider;
+use aws_credential_types::provider::{error::CredentialsError, future, ProvideCredentials};
+use aws_credential_types::Credentials;
+use aws_runtime::env_config::file::{EnvConfigFileKind, EnvConfigFiles};
+use tokio::task::JoinHandle;
+
+/// How often the background task checks for updated credentials on disk.
+fn reload_delay() -> Duration {
+    #[cfg(debug_assertions)]
+    if let Ok(secs) = std::env::var("SMA_CREDENTIALS_RELOAD_SECS") {
+        if let Ok(val) = secs.parse() {
+            return Duration::from_secs(val);
+        }
+    }
+    Duration::from_secs(5 * 60)
+}
+
+/// How long the SDK considers the credentials valid before asking the provider again.
+const SDK_CREDENTIALS_TTL: Duration = Duration::from_secs(10 * 60);
+
+/// A credentials provider that reads AWS credentials from a file and
+/// automatically reloads them on a configurable interval.
+///
+/// Enforces a session token gate: credentials without an `aws_session_token`
+/// are rejected to prevent use of long-term IAM User credentials.
+#[derive(Debug, Clone)]
+pub struct FileBasedCredentialsProvider {
+    cached: Arc<ArcSwapOption<Credentials>>,
+    _reload_handle: Arc<ReloadHandle>,
+}
+
+#[derive(Debug)]
+struct ReloadHandle(JoinHandle<()>);
+
+impl Drop for ReloadHandle {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+impl FileBasedCredentialsProvider {
+    /// Create a new provider that reads credentials from the given path.
+    ///
+    /// Attempts an initial load but does not fail if the file is missing or
+    /// malformed — the background reload task will pick up valid credentials
+    /// when they appear.
+    pub async fn new(path: impl Into<PathBuf>) -> Self {
+        let path = path.into();
+        let cached = Arc::new(ArcSwapOption::new(None));
+
+        match load_and_validate(&path).await {
+            Ok(creds) => {
+                cached.store(Some(Arc::new(creds)));
+                warn_if_broad_permissions(&path);
+                log::info!("Loaded file-based credentials from: {}", path.display());
+            }
+            Err(e) => {
+                log::warn!(
+                    "Could not load credentials from {}: {}. \
+                     The agent will retry every {} seconds.",
+                    path.display(),
+                    e,
+                    reload_delay().as_secs()
+                );
+            }
+        }
+
+        let reload_cached = cached.clone();
+        let handle = tokio::spawn(async move {
+            let mut last_modified = file_modified_time(&path);
+            let mut interval = tokio::time::interval(reload_delay());
+            interval.tick().await; // skip immediate first tick
+            loop {
+                interval.tick().await;
+
+                let current_modified = file_modified_time(&path);
+                if current_modified == last_modified {
+                    continue;
+                }
+
+                match load_and_validate(&path).await {
+                    Ok(creds) => {
+                        reload_cached.store(Some(Arc::new(creds)));
+                        last_modified = current_modified;
+                        warn_if_broad_permissions(&path);
+                        log::debug!(
+                            "Successfully reloaded credentials from {}",
+                            path.display()
+                        );
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "Failed to reload credentials from {}: {}",
+                            path.display(),
+                            e
+                        );
+                    }
+                }
+            }
+        });
+
+        Self {
+            cached,
+            _reload_handle: Arc::new(ReloadHandle(handle)),
+        }
+    }
+}
+
+impl ProvideCredentials for FileBasedCredentialsProvider {
+    fn provide_credentials<'a>(&'a self) -> future::ProvideCredentials<'a>
+    where
+        Self: 'a,
+    {
+        future::ProvideCredentials::new(async {
+            self.cached
+                .load()
+                .as_ref()
+                .map(|c| with_expiry((**c).clone()))
+                .ok_or_else(|| CredentialsError::not_loaded("No credentials available"))
+        })
+    }
+}
+
+/// Parse credentials from a file and validate they contain a session token.
+async fn load_and_validate(path: &Path) -> Result<Credentials, CredentialsError> {
+    let creds = load_from_file(path).await?;
+
+    if creds.session_token().is_none() {
+        return Err(CredentialsError::provider_error(
+            "Security Policy Violation: Long-term IAM User credentials are not permitted. \
+             The credentials file must contain temporary credentials with an aws_session_token.",
+        ));
+    }
+
+    Ok(creds)
+}
+
+/// Parse credentials from a file using the AWS SDK's profile file parser.
+async fn load_from_file(path: &Path) -> Result<Credentials, CredentialsError> {
+    let env_config_files = EnvConfigFiles::builder()
+        .with_file(EnvConfigFileKind::Credentials, path)
+        .build();
+
+    ProfileFileCredentialsProvider::builder()
+        .profile_files(env_config_files)
+        .build()
+        .provide_credentials()
+        .await
+}
+
+/// Wrap credentials with an SDK expiry so the SDK knows when to ask again.
+fn with_expiry(creds: Credentials) -> Credentials {
+    Credentials::new(
+        creds.access_key_id(),
+        creds.secret_access_key(),
+        creds.session_token().map(|s| s.to_string()),
+        Some(SystemTime::now() + SDK_CREDENTIALS_TTL),
+        "FileBasedCredentialsProvider",
+    )
+}
+
+fn file_modified_time(path: &Path) -> Option<SystemTime> {
+    std::fs::metadata(path).and_then(|m| m.modified()).ok()
+}
+
+#[cfg(unix)]
+fn warn_if_broad_permissions(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    if let Ok(metadata) = std::fs::metadata(path) {
+        let mode = metadata.permissions().mode();
+        if mode & 0o077 != 0 {
+            log::warn!(
+                "Credentials file {} has broad permissions ({:o}). \
+                 Consider restricting to owner-only (chmod 600).",
+                path.display(),
+                mode & 0o777
+            );
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn warn_if_broad_permissions(_path: &Path) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_valid_credentials(file: &mut NamedTempFile) {
+        writeln!(
+            file,
+            "[default]\naws_access_key_id=AKIAIOSFODNN7EXAMPLE\naws_secret_access_key=wJalrXUtnFEMI\naws_session_token=FwoGZX"
+        )
+        .unwrap();
+    }
+
+    fn write_long_term_credentials(file: &mut NamedTempFile) {
+        writeln!(
+            file,
+            "[default]\naws_access_key_id=AKIAIOSFODNN7EXAMPLE\naws_secret_access_key=wJalrXUtnFEMI"
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_load_valid_credentials() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        write_valid_credentials(&mut tmp);
+
+        let provider = FileBasedCredentialsProvider::new(tmp.path()).await;
+        let creds = provider.provide_credentials().await.unwrap();
+
+        assert_eq!(creds.access_key_id(), "AKIAIOSFODNN7EXAMPLE");
+        assert_eq!(creds.secret_access_key(), "wJalrXUtnFEMI");
+        assert_eq!(creds.session_token(), Some("FwoGZX"));
+    }
+
+    #[tokio::test]
+    async fn test_rejects_long_term_credentials() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        write_long_term_credentials(&mut tmp);
+
+        let provider = FileBasedCredentialsProvider::new(tmp.path()).await;
+        let result = provider.provide_credentials().await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_missing_file_starts_with_empty_cache() {
+        let provider = FileBasedCredentialsProvider::new("/nonexistent/path").await;
+        let result = provider.provide_credentials().await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_empty_file_starts_with_empty_cache() {
+        let tmp = NamedTempFile::new().unwrap();
+        let provider = FileBasedCredentialsProvider::new(tmp.path()).await;
+        let result = provider.provide_credentials().await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_credential_reload() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        write_valid_credentials(&mut tmp);
+
+        let provider = FileBasedCredentialsProvider::new(tmp.path()).await;
+        assert_eq!(
+            provider.provide_credentials().await.unwrap().access_key_id(),
+            "AKIAIOSFODNN7EXAMPLE"
+        );
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        std::fs::write(
+            tmp.path(),
+            "[default]\naws_access_key_id=ROTATED_KEY\naws_secret_access_key=secret\naws_session_token=token",
+        )
+        .unwrap();
+
+        tmp.as_file()
+            .set_modified(SystemTime::now() + Duration::from_secs(60))
+            .unwrap();
+
+        tokio::time::pause();
+        tokio::time::advance(reload_delay()).await;
+        tokio::time::resume();
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        assert_eq!(
+            provider.provide_credentials().await.unwrap().access_key_id(),
+            "ROTATED_KEY"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_reload_rejects_long_term_retains_cached() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        write_valid_credentials(&mut tmp);
+
+        let provider = FileBasedCredentialsProvider::new(tmp.path()).await;
+        assert_eq!(
+            provider.provide_credentials().await.unwrap().access_key_id(),
+            "AKIAIOSFODNN7EXAMPLE"
+        );
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        // Write long-term creds (no session token) — should be rejected
+        std::fs::write(
+            tmp.path(),
+            "[default]\naws_access_key_id=LONGTERM\naws_secret_access_key=secret",
+        )
+        .unwrap();
+        tmp.as_file()
+            .set_modified(SystemTime::now() + Duration::from_secs(60))
+            .unwrap();
+
+        tokio::time::pause();
+        tokio::time::advance(reload_delay()).await;
+        tokio::time::resume();
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        // Should still have the original valid credentials
+        assert_eq!(
+            provider.provide_credentials().await.unwrap().access_key_id(),
+            "AKIAIOSFODNN7EXAMPLE"
+        );
+    }
+}

--- a/aws_secretsmanager_provider/src/credentials_file_provider.rs
+++ b/aws_secretsmanager_provider/src/credentials_file_provider.rs
@@ -53,7 +53,7 @@ impl FileBasedCredentialsProvider {
         let path = path.into();
         let cached = Arc::new(ArcSwapOption::new(None));
 
-        match load_and_validate(&path).await {
+        match CredentialsLoader::new(&path).load_and_validate().await {
             Ok(creds) => {
                 cached.store(Some(Arc::new(creds)));
                 warn_if_broad_permissions(&path);
@@ -83,15 +83,12 @@ impl FileBasedCredentialsProvider {
                     continue;
                 }
 
-                match load_and_validate(&path).await {
+                match CredentialsLoader::new(&path).load_and_validate().await {
                     Ok(creds) => {
                         reload_cached.store(Some(Arc::new(creds)));
                         last_modified = current_modified;
                         warn_if_broad_permissions(&path);
-                        log::debug!(
-                            "Successfully reloaded credentials from {}",
-                            path.display()
-                        );
+                        log::debug!("Successfully reloaded credentials from {}", path.display());
                     }
                     Err(e) => {
                         log::warn!(
@@ -126,31 +123,41 @@ impl ProvideCredentials for FileBasedCredentialsProvider {
     }
 }
 
-/// Parse credentials from a file and validate they contain a session token.
-async fn load_and_validate(path: &Path) -> Result<Credentials, CredentialsError> {
-    let creds = load_from_file(path).await?;
-
-    if creds.session_token().is_none() {
-        return Err(CredentialsError::provider_error(
-            "Security Policy Violation: Long-term IAM User credentials are not permitted. \
-             The credentials file must contain temporary credentials with an aws_session_token.",
-        ));
-    }
-
-    Ok(creds)
+struct CredentialsLoader<'a> {
+    path: &'a Path,
 }
 
-/// Parse credentials from a file using the AWS SDK's profile file parser.
-async fn load_from_file(path: &Path) -> Result<Credentials, CredentialsError> {
-    let env_config_files = EnvConfigFiles::builder()
-        .with_file(EnvConfigFileKind::Credentials, path)
-        .build();
+impl<'a> CredentialsLoader<'a> {
+    fn new(path: &'a Path) -> Self {
+        Self { path }
+    }
 
-    ProfileFileCredentialsProvider::builder()
-        .profile_files(env_config_files)
-        .build()
-        .provide_credentials()
-        .await
+    /// Parse credentials from the file and validate they contain a session token.
+    async fn load_and_validate(&self) -> Result<Credentials, CredentialsError> {
+        let creds = self.load_from_file().await?;
+
+        if creds.session_token().is_none() {
+            return Err(CredentialsError::provider_error(
+                "Security Policy Violation: Long-term IAM User credentials are not permitted. \
+                 The credentials file must contain temporary credentials with an aws_session_token.",
+            ));
+        }
+
+        Ok(creds)
+    }
+
+    /// Parse credentials from the file using the AWS SDK's profile file parser.
+    async fn load_from_file(&self) -> Result<Credentials, CredentialsError> {
+        let env_config_files = EnvConfigFiles::builder()
+            .with_file(EnvConfigFileKind::Credentials, self.path)
+            .build();
+
+        ProfileFileCredentialsProvider::builder()
+            .profile_files(env_config_files)
+            .build()
+            .provide_credentials()
+            .await
+    }
 }
 
 /// Wrap credentials with an SDK expiry so the SDK knows when to ask again.
@@ -254,7 +261,11 @@ mod tests {
 
         let provider = FileBasedCredentialsProvider::new(tmp.path()).await;
         assert_eq!(
-            provider.provide_credentials().await.unwrap().access_key_id(),
+            provider
+                .provide_credentials()
+                .await
+                .unwrap()
+                .access_key_id(),
             "AKIAIOSFODNN7EXAMPLE"
         );
 
@@ -276,7 +287,11 @@ mod tests {
         tokio::time::sleep(Duration::from_secs(1)).await;
 
         assert_eq!(
-            provider.provide_credentials().await.unwrap().access_key_id(),
+            provider
+                .provide_credentials()
+                .await
+                .unwrap()
+                .access_key_id(),
             "ROTATED_KEY"
         );
     }
@@ -288,7 +303,11 @@ mod tests {
 
         let provider = FileBasedCredentialsProvider::new(tmp.path()).await;
         assert_eq!(
-            provider.provide_credentials().await.unwrap().access_key_id(),
+            provider
+                .provide_credentials()
+                .await
+                .unwrap()
+                .access_key_id(),
             "AKIAIOSFODNN7EXAMPLE"
         );
 
@@ -311,7 +330,11 @@ mod tests {
 
         // Should still have the original valid credentials
         assert_eq!(
-            provider.provide_credentials().await.unwrap().access_key_id(),
+            provider
+                .provide_credentials()
+                .await
+                .unwrap()
+                .access_key_id(),
             "AKIAIOSFODNN7EXAMPLE"
         );
     }

--- a/aws_secretsmanager_provider/src/lib.rs
+++ b/aws_secretsmanager_provider/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod cache_manager;
 mod constants;
+pub mod credentials_file_provider;
 mod error;
 mod parse;
 mod prefetch;

--- a/aws_secretsmanager_provider/src/utils.rs
+++ b/aws_secretsmanager_provider/src/utils.rs
@@ -125,19 +125,46 @@ pub fn time_out_test() -> Duration {
 #[cfg(not(test))]
 pub async fn validate_and_create_asm_client(
     config: &SecretsManagerConfig,
-) -> Result<SecretsManagerClient, Box<dyn std::error::Error>> {
+) -> Result<(SecretsManagerClient, aws_config::SdkConfig), Box<dyn std::error::Error>> {
     use aws_config::{BehaviorVersion, Region};
     use aws_secretsmanager_caching::error::is_transient_error;
-    let default_config = &aws_config::load_defaults(BehaviorVersion::latest()).await;
-    let mut asm_builder = aws_sdk_secretsmanager::config::Builder::from(default_config)
+
+    use crate::credentials_file_provider::FileBasedCredentialsProvider;
+
+    let mut sdk_config = aws_config::load_defaults(BehaviorVersion::latest()).await;
+
+    // Use file-based credentials if configured.
+    let has_file_provider = if let Some(path) = discover_credentials_file(config) {
+        log::info!("Using file-based credentials from: {}", path.display());
+        let provider = FileBasedCredentialsProvider::new(&path).await;
+        sdk_config = sdk_config
+            .into_builder()
+            .credentials_provider(
+                aws_sdk_secretsmanager::config::SharedCredentialsProvider::new(provider),
+            )
+            .build();
+        true
+    } else {
+        log::info!("No credentials file found, using default SDK credential chain");
+        false
+    };
+
+    let mut asm_builder = aws_sdk_secretsmanager::config::Builder::from(&sdk_config)
         .interceptor(AgentModifierInterceptor);
+
+    #[cfg(debug_assertions)]
+    if std::env::var("SMA_DISABLE_IDENTITY_CACHE").is_ok() {
+        log::info!("Identity caching disabled via SMA_DISABLE_IDENTITY_CACHE");
+        asm_builder = asm_builder
+            .identity_cache(aws_sdk_secretsmanager::config::IdentityCache::no_cache());
+    }
 
     if let Some(ref region) = config.region {
         asm_builder.set_region(Some(Region::new(region.clone())));
     }
 
-    if config.validate_credentials {
-        let mut sts_builder = aws_sdk_sts::config::Builder::from(default_config);
+    if config.validate_credentials && !has_file_provider {
+        let mut sts_builder = aws_sdk_sts::config::Builder::from(&sdk_config);
         if let Some(ref region) = config.region {
             sts_builder.set_region(Some(Region::new(region.clone())));
         }
@@ -148,11 +175,36 @@ pub async fn validate_and_create_asm_client(
             Err(e) if config.ignore_transient_errors && is_transient_error(&e) => (),
             Err(e) => Err(e)?,
         };
+    } else if has_file_provider {
+        log::info!("Skipping STS credential validation for file-based credentials");
     }
 
-    Ok(aws_sdk_secretsmanager::Client::from_conf(
-        asm_builder.build(),
+    Ok((
+        aws_sdk_secretsmanager::Client::from_conf(asm_builder.build()),
+        sdk_config,
     ))
+}
+
+/// Discover a credentials file from explicit config.
+///
+/// Returns the configured credentials file path, if set.
+/// If the configured path does not exist yet, it is still returned — the provider
+/// will start with an empty cache and the background reload will pick up the file
+/// when it appears.
+#[cfg(not(test))]
+fn discover_credentials_file(config: &SecretsManagerConfig) -> Option<std::path::PathBuf> {
+    if let Some(path) = &config.credentials_file_path {
+        if !path.is_file() {
+            log::warn!(
+                "Configured credentials_file_path does not exist yet: {}. \
+                 The agent will watch for it to appear.",
+                path.display()
+            );
+        }
+        return Some(path.clone());
+    }
+
+    None
 }
 
 /// SDK interceptor to append the agent name and version to the User-Agent header for CloudTrail records.

--- a/aws_secretsmanager_provider/src/utils.rs
+++ b/aws_secretsmanager_provider/src/utils.rs
@@ -155,8 +155,8 @@ pub async fn validate_and_create_asm_client(
     #[cfg(debug_assertions)]
     if std::env::var("SMA_DISABLE_IDENTITY_CACHE").is_ok() {
         log::info!("Identity caching disabled via SMA_DISABLE_IDENTITY_CACHE");
-        asm_builder = asm_builder
-            .identity_cache(aws_sdk_secretsmanager::config::IdentityCache::no_cache());
+        asm_builder =
+            asm_builder.identity_cache(aws_sdk_secretsmanager::config::IdentityCache::no_cache());
     }
 
     if let Some(ref region) = config.region {

--- a/aws_workload_credentials_provider_common/src/config/types.rs
+++ b/aws_workload_credentials_provider_common/src/config/types.rs
@@ -87,6 +87,9 @@ pub struct SecretsManagerConfig {
 
     /// Pre-fetch configuration for warming the cache at startup
     pub prefetch: PrefetchConfig,
+
+    /// Optional path to a credentials file for file-based credential loading
+    pub credentials_file_path: Option<PathBuf>,
 }
 
 impl Default for SecretsManagerConfig {
@@ -103,6 +106,7 @@ impl Default for SecretsManagerConfig {
             ignore_transient_errors: true,
             validate_credentials: true,
             prefetch: PrefetchConfig::default(),
+            credentials_file_path: None,
         }
     }
 }
@@ -299,6 +303,7 @@ pub struct ConfigInput {
     pub validate_credentials: Option<bool>,
     #[serde(default)]
     pub prefetch: Option<PrefetchConfigInput>,
+    pub credentials_file_path: Option<PathBuf>,
 
     // Nested capabilities
     pub capabilities: Option<CapabilitiesConfig>,
@@ -331,6 +336,7 @@ pub struct SecretsManagerConfigInput {
     pub validate_credentials: Option<bool>,
     #[serde(default)]
     pub prefetch: Option<PrefetchConfigInput>,
+    pub credentials_file_path: Option<PathBuf>,
 }
 
 /// Cache configuration in nested format.

--- a/aws_workload_credentials_provider_common/src/config/validator.rs
+++ b/aws_workload_credentials_provider_common/src/config/validator.rs
@@ -387,16 +387,9 @@ impl<F: FileSystem> ConfigValidator<F> {
             secrets_manager_config.validate_credentials = validate_credentials;
         }
 
-        if let Some(ref path) = secrets_manager_config_input.credentials_file_path {
-            if !path.is_file() {
-                log::warn!(
-                    "Configured credentials_file_path does not exist yet: {}. \
-                     The agent will watch for it to appear.",
-                    path.display()
-                );
-            }
-            secrets_manager_config.credentials_file_path =
-                secrets_manager_config_input.credentials_file_path;
+        if let Some(path) = secrets_manager_config_input.credentials_file_path {
+            warn_if_credentials_file_missing(&path);
+            secrets_manager_config.credentials_file_path = Some(path);
         }
 
         if let Some(prefetch_input) = secrets_manager_config_input.prefetch {
@@ -632,15 +625,9 @@ impl<F: FileSystem> ConfigValidator<F> {
             secrets_manager_config.validate_credentials = validate_credentials;
         }
 
-        if let Some(ref path) = config_file.credentials_file_path {
-            if !path.is_file() {
-                log::warn!(
-                    "Configured credentials_file_path does not exist yet: {}. \
-                     The agent will watch for it to appear.",
-                    path.display()
-                );
-            }
-            secrets_manager_config.credentials_file_path = config_file.credentials_file_path.clone();
+        if let Some(path) = config_file.credentials_file_path.clone() {
+            warn_if_credentials_file_missing(&path);
+            secrets_manager_config.credentials_file_path = Some(path);
         }
 
         if let Some(prefetch_input) = config_file.prefetch.clone() {
@@ -897,6 +884,16 @@ impl<F: FileSystem> ConfigValidator<F> {
 impl Default for ConfigValidator<RealFileSystem> {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+fn warn_if_credentials_file_missing(path: &std::path::Path) {
+    if !path.is_file() {
+        log::warn!(
+            "Configured credentials_file_path does not exist yet: {}. \
+             The agent will watch for it to appear.",
+            path.display()
+        );
     }
 }
 

--- a/aws_workload_credentials_provider_common/src/config/validator.rs
+++ b/aws_workload_credentials_provider_common/src/config/validator.rs
@@ -216,6 +216,11 @@ impl<F: FileSystem> ConfigValidator<F> {
             "capabilities.secrets_manager.validate_credentials",
         );
         reject(
+            "credentials_file_path",
+            config_file.credentials_file_path.is_some(),
+            "capabilities.secrets_manager.credentials_file_path",
+        );
+        reject(
             "log_level",
             config_file.log_level.is_some(),
             "logging.log_level",
@@ -380,6 +385,18 @@ impl<F: FileSystem> ConfigValidator<F> {
 
         if let Some(validate_credentials) = secrets_manager_config_input.validate_credentials {
             secrets_manager_config.validate_credentials = validate_credentials;
+        }
+
+        if let Some(ref path) = secrets_manager_config_input.credentials_file_path {
+            if !path.is_file() {
+                log::warn!(
+                    "Configured credentials_file_path does not exist yet: {}. \
+                     The agent will watch for it to appear.",
+                    path.display()
+                );
+            }
+            secrets_manager_config.credentials_file_path =
+                secrets_manager_config_input.credentials_file_path;
         }
 
         if let Some(prefetch_input) = secrets_manager_config_input.prefetch {
@@ -613,6 +630,17 @@ impl<F: FileSystem> ConfigValidator<F> {
 
         if let Some(validate_credentials) = config_file.validate_credentials {
             secrets_manager_config.validate_credentials = validate_credentials;
+        }
+
+        if let Some(ref path) = config_file.credentials_file_path {
+            if !path.is_file() {
+                log::warn!(
+                    "Configured credentials_file_path does not exist yet: {}. \
+                     The agent will watch for it to appear.",
+                    path.display()
+                );
+            }
+            secrets_manager_config.credentials_file_path = config_file.credentials_file_path.clone();
         }
 
         if let Some(prefetch_input) = config_file.prefetch.clone() {

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -10,6 +10,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "net", "macros", "test-u
 reqwest = "0.13"
 serde_json = "1"
 aws-config = "1"
+aws-credential-types = "1"
 aws-sdk-secretsmanager = "1"
 aws-sdk-sts = "1"
 url = "2"

--- a/integration-tests/tests/common.rs
+++ b/integration-tests/tests/common.rs
@@ -153,6 +153,53 @@ ttl_seconds = {}
         }
     }
 
+    /// Start the provider with a custom config and extra environment variables.
+    #[allow(dead_code)]
+    pub async fn start_with_config_content_and_env(
+        port: u16,
+        config_content: &str,
+        extra_env: &[(&str, &str)],
+    ) -> ProviderProcess {
+        let config_path = std::env::temp_dir().join(format!("test_config_{}.toml", port));
+        std::fs::write(&config_path, config_content).expect("Failed to write test config");
+
+        let provider_path = locate_provider_binary();
+
+        let mut cmd = TokioCommand::new(&provider_path);
+        cmd.arg("sm")
+            .arg("start")
+            .arg("--config")
+            .arg(&config_path)
+            .env("AWS_TOKEN", "test-token-123")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+
+        for (key, val) in extra_env {
+            cmd.env(key, val);
+        }
+
+        let mut child = cmd.spawn().expect("Failed to start provider");
+
+        let stdout = child.stdout.take().expect("Failed to get stdout");
+        let mut reader = BufReader::new(stdout).lines();
+
+        match reader.next_line().await {
+            Ok(Some(line)) => {
+                if !line.contains("listening on") {
+                    panic!("Provider failed to start - no listening message found");
+                }
+            }
+            Ok(None) => panic!("Stream ended without finding listening message"),
+            Err(e) => panic!("Failed to read provider output: {}", e),
+        }
+
+        ProviderProcess {
+            _child: child,
+            port,
+        }
+    }
+
     #[allow(dead_code)]
     pub async fn make_request(&self, query: &ProviderQuery) -> String {
         let response = self.make_request_raw(query).await;

--- a/integration-tests/tests/common.rs
+++ b/integration-tests/tests/common.rs
@@ -154,7 +154,6 @@ ttl_seconds = {}
     }
 
     /// Start the provider with a custom config and extra environment variables.
-    #[allow(dead_code)]
     pub async fn start_with_config_content_and_env(
         port: u16,
         config_content: &str,

--- a/integration-tests/tests/file_credentials.rs
+++ b/integration-tests/tests/file_credentials.rs
@@ -1,0 +1,400 @@
+//! # File-Based Credentials Integration Tests
+//!
+//! Tests for the FileBasedCredentialsProvider feature, verifying the agent
+//! correctly handles various credential file scenarios.
+//!
+//! **Note:** `test_self_healing_credentials_appear_after_startup` and
+//! `test_credential_rotation_while_running` use `SMA_CREDENTIALS_RELOAD_SECS`.
+//! This env-var override is only active in debug builds of the provider binary.
+
+mod common;
+
+use aws_credential_types::provider::ProvideCredentials;
+use common::*;
+use std::io::Write;
+use tempfile::NamedTempFile;
+
+/// Helper to write real AWS credentials from the environment to a temp file.
+async fn write_real_credentials(file: &mut NamedTempFile) {
+    let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+    let creds = config
+        .credentials_provider()
+        .expect("No credentials provider")
+        .provide_credentials()
+        .await
+        .expect("Failed to resolve credentials");
+
+    let mut content = format!(
+        "[default]\naws_access_key_id={}\naws_secret_access_key={}\n",
+        creds.access_key_id(),
+        creds.secret_access_key()
+    );
+    if let Some(token) = creds.session_token() {
+        content.push_str(&format!("aws_session_token={}\n", token));
+    }
+    file.write_all(content.as_bytes()).unwrap();
+    file.flush().unwrap();
+}
+
+/// Valid credentials via explicit path: provider starts and can fetch a secret.
+#[tokio::test]
+async fn test_valid_credentials_explicit_path() {
+    let secrets = TestSecrets::setup_basic().await;
+    let secret_name = secrets.secret_name(&SecretType::Basic);
+
+    let mut creds_file = NamedTempFile::new().unwrap();
+    write_real_credentials(&mut creds_file).await;
+
+    let config_content = format!(
+        r#"
+[logging]
+log_level = "debug"
+
+[capabilities.secrets_manager]
+http_port = 2885
+credentials_file_path = "{}"
+"#,
+        creds_file.path().display()
+    );
+
+    let provider = ProviderProcess::start_with_config_content(2885, &config_content).await;
+
+    let query = ProviderQueryBuilder::default()
+        .secret_id(&secret_name)
+        .build()
+        .unwrap();
+    let response = provider.make_request(&query).await;
+    let json: serde_json::Value = serde_json::from_str(&response).unwrap();
+
+    assert_eq!(json["Name"], secret_name);
+    assert!(json["SecretString"].as_str().unwrap().contains("testuser"));
+}
+
+/// Invalid credentials: provider starts but secret fetch returns auth error.
+#[tokio::test]
+async fn test_invalid_credentials_provider_starts() {
+    let mut creds_file = NamedTempFile::new().unwrap();
+    writeln!(
+        creds_file,
+        "[default]\naws_access_key_id=AKIAIOSFODNN7EXAMPLE\naws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\naws_session_token=FakeSessionToken"
+    )
+    .unwrap();
+
+    let config_content = format!(
+        r#"
+[logging]
+log_level = "debug"
+
+[capabilities.secrets_manager]
+http_port = 2886
+credentials_file_path = "{}"
+"#,
+        creds_file.path().display()
+    );
+
+    let provider = ProviderProcess::start_with_config_content(2886, &config_content).await;
+
+    let query = ProviderQueryBuilder::default()
+        .secret_id("any-secret")
+        .build()
+        .unwrap();
+    let response = provider.make_request_raw(&query).await;
+
+    assert_ne!(response.status(), 200);
+}
+
+/// Long-term credentials (no session token): provider starts but credentials are rejected.
+#[tokio::test]
+async fn test_long_term_credentials_rejected() {
+    let mut creds_file = NamedTempFile::new().unwrap();
+    writeln!(
+        creds_file,
+        "[default]\naws_access_key_id=AKIAIOSFODNN7EXAMPLE\naws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    )
+    .unwrap();
+
+    let config_content = format!(
+        r#"
+[logging]
+log_level = "debug"
+
+[capabilities.secrets_manager]
+http_port = 2887
+credentials_file_path = "{}"
+"#,
+        creds_file.path().display()
+    );
+
+    let provider = ProviderProcess::start_with_config_content(2887, &config_content).await;
+
+    let query = ProviderQueryBuilder::default()
+        .secret_id("any-secret")
+        .build()
+        .unwrap();
+    let response = provider.make_request_raw(&query).await;
+
+    assert_ne!(response.status(), 200);
+}
+
+/// Malformed credentials file: provider starts, request returns error.
+#[tokio::test]
+async fn test_malformed_credentials_file() {
+    let mut creds_file = NamedTempFile::new().unwrap();
+    writeln!(creds_file, "this is not a credentials file").unwrap();
+
+    let config_content = format!(
+        r#"
+[logging]
+log_level = "debug"
+
+[capabilities.secrets_manager]
+http_port = 2890
+credentials_file_path = "{}"
+"#,
+        creds_file.path().display()
+    );
+
+    let provider = ProviderProcess::start_with_config_content(2890, &config_content).await;
+
+    let query = ProviderQueryBuilder::default()
+        .secret_id("any-secret")
+        .build()
+        .unwrap();
+    let response = provider.make_request_raw(&query).await;
+
+    assert_ne!(response.status(), 200);
+}
+
+/// Empty credentials file: provider starts, request returns error.
+#[tokio::test]
+async fn test_empty_credentials_file() {
+    let creds_file = NamedTempFile::new().unwrap();
+
+    let config_content = format!(
+        r#"
+[logging]
+log_level = "debug"
+
+[capabilities.secrets_manager]
+http_port = 2891
+credentials_file_path = "{}"
+"#,
+        creds_file.path().display()
+    );
+
+    let provider = ProviderProcess::start_with_config_content(2891, &config_content).await;
+
+    let query = ProviderQueryBuilder::default()
+        .secret_id("any-secret")
+        .build()
+        .unwrap();
+    let response = provider.make_request_raw(&query).await;
+
+    assert_ne!(response.status(), 200);
+}
+
+/// Missing credentials path: provider starts, request fails.
+#[tokio::test]
+async fn test_missing_credentials_path() {
+    let config_content = r#"
+[logging]
+log_level = "debug"
+
+[capabilities.secrets_manager]
+http_port = 2888
+credentials_file_path = "/tmp/nonexistent_creds_file_integ_test"
+"#;
+
+    let provider = ProviderProcess::start_with_config_content(2888, config_content).await;
+
+    let query = ProviderQueryBuilder::default()
+        .secret_id("any-secret")
+        .build()
+        .unwrap();
+    let response = provider.make_request_raw(&query).await;
+
+    assert_ne!(response.status(), 200);
+}
+
+/// Self-healing: provider starts with missing credentials, valid creds are written later,
+/// provider picks them up on the next reload cycle.
+#[tokio::test]
+async fn test_self_healing_credentials_appear_after_startup() {
+    let secrets = TestSecrets::setup_basic().await;
+    let secret_name = secrets.secret_name(&SecretType::Basic);
+
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let creds_path = tmp_dir.path().join("credentials");
+
+    let config_content = format!(
+        r#"
+[logging]
+log_level = "debug"
+
+[capabilities.secrets_manager]
+http_port = 2889
+credentials_file_path = "{}"
+"#,
+        creds_path.display()
+    );
+
+    let provider = ProviderProcess::start_with_config_content_and_env(
+        2889,
+        &config_content,
+        &[("SMA_CREDENTIALS_RELOAD_SECS", "3")],
+    )
+    .await;
+
+    // First request should fail — no credentials yet
+    let query = ProviderQueryBuilder::default()
+        .secret_id(&secret_name)
+        .build()
+        .unwrap();
+    let response = provider.make_request_raw(&query).await;
+    assert_ne!(response.status(), 200);
+
+    // Write valid credentials
+    let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+    let creds = config
+        .credentials_provider()
+        .expect("No credentials provider")
+        .provide_credentials()
+        .await
+        .expect("Failed to resolve credentials");
+
+    let mut content = format!(
+        "[default]\naws_access_key_id={}\naws_secret_access_key={}\n",
+        creds.access_key_id(),
+        creds.secret_access_key()
+    );
+    if let Some(token) = creds.session_token() {
+        content.push_str(&format!("aws_session_token={}\n", token));
+    }
+    std::fs::write(&creds_path, content).unwrap();
+
+    // Poll until the provider picks up credentials
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
+    loop {
+        let resp = provider.make_request_raw(&query).await;
+        if resp.status() == 200 {
+            let body = resp.text().await.unwrap();
+            let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+            assert_eq!(json["Name"], secret_name);
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "Timed out waiting for credentials reload"
+        );
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    }
+}
+
+/// Credential rotation: provider starts with valid credentials, credentials are
+/// rotated to invalid, provider fails, then valid credentials are restored and
+/// provider recovers. Proves the provider is actively re-reading the file.
+#[tokio::test]
+async fn test_credential_rotation_while_running() {
+    let secrets = TestSecrets::setup_basic().await;
+    let secret_name = secrets.secret_name(&SecretType::Basic);
+
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let creds_path = tmp_dir.path().join("credentials");
+
+    // Write initial valid credentials
+    let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+    let creds = config
+        .credentials_provider()
+        .expect("No credentials provider")
+        .provide_credentials()
+        .await
+        .expect("Failed to resolve credentials");
+
+    let mut valid_content = format!(
+        "[default]\naws_access_key_id={}\naws_secret_access_key={}\n",
+        creds.access_key_id(),
+        creds.secret_access_key()
+    );
+    if let Some(token) = creds.session_token() {
+        valid_content.push_str(&format!("aws_session_token={}\n", token));
+    }
+    std::fs::write(&creds_path, &valid_content).unwrap();
+
+    // Start provider with short reload delay
+    let config_content = format!(
+        r#"
+[logging]
+log_level = "debug"
+
+[capabilities.secrets_manager]
+http_port = 2893
+credentials_file_path = "{}"
+"#,
+        creds_path.display()
+    );
+
+    let provider = ProviderProcess::start_with_config_content_and_env(
+        2893,
+        &config_content,
+        &[
+            ("SMA_CREDENTIALS_RELOAD_SECS", "3"),
+            ("SMA_DISABLE_IDENTITY_CACHE", "1"),
+        ],
+    )
+    .await;
+
+    // Step 1: Verify provider works with initial valid credentials
+    let query = ProviderQueryBuilder::default()
+        .secret_id(&secret_name)
+        .build()
+        .unwrap();
+    let response = provider.make_request(&query).await;
+    let json: serde_json::Value = serde_json::from_str(&response).unwrap();
+    assert_eq!(json["Name"], secret_name);
+
+    // Step 2: Overwrite with invalid credentials (has session token to pass gate)
+    std::fs::write(
+        &creds_path,
+        "[default]\naws_access_key_id=AKIAIOSFODNN7EXAMPLE\naws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\naws_session_token=FakeSessionToken\n",
+    )
+    .unwrap();
+
+    // Poll until provider returns errors (proves it picked up invalid creds)
+    let refresh_query = ProviderQueryBuilder::default()
+        .secret_id(&secret_name)
+        .refresh_now(true)
+        .build()
+        .unwrap();
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(20);
+    loop {
+        let resp = provider.make_request_raw(&refresh_query).await;
+        if resp.status() != 200 {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "Timed out waiting for provider to pick up invalid credentials"
+        );
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+
+    // Step 3: Restore valid credentials
+    std::fs::write(&creds_path, &valid_content).unwrap();
+
+    // Poll until provider recovers
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(20);
+    loop {
+        let resp = provider.make_request_raw(&refresh_query).await;
+        if resp.status() == 200 {
+            let body = resp.text().await.unwrap();
+            let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+            assert_eq!(json["Name"], secret_name);
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "Timed out waiting for provider to recover with valid credentials"
+        );
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+}


### PR DESCRIPTION
### Summary

Re-implements the file-based credential provider (originally merged in #192, reverted in #201) with a mandatory session token gate that prevents use of long-term IAM User credentials. This enables the Workload Credentials Provider to stay in sync with temporary credentials rotated on disk by systems like [IAM Roles Anywhere](https://docs.aws.amazon.com/rolesanywhere/latest/userguide/introduction.html).

### Motivation

The AWS SDK for Rust's ProfileFileCredentialsProvider reads the credentials file once and caches the result indefinitely. For on-premises or multicloud environments where IAM Roles Anywhere's credential helper writes rotating temporary credentials to ~/.aws/credentials, the provider becomes unable to fetch secrets once the initial credentials expire. This change restores file-based credential refresh with an explicit security gate.

### What's new vs the original implementation (#192)

| Change | Rationale |
|--------|-----------|
| **Session token gate** — `load_and_validate()` rejects credentials without `aws_session_token` on both initial load and every 5-minute reload | Addresses the security concern that caused the revert: prevents long-term IAM User credentials from being used via the file path |
| **Role chaining integration** — `base_sdk_config` in `CacheManager` inherits the file provider | Role chaining was added after the revert; cross-account AssumeRole calls now use file-based credentials when configured |
| **Nested config format support** — `credentials_file_path` works under `[capabilities.secrets_manager]` and in `reject_flat_keys` | The config system was restructured to support nested TOML; this field follows the new convention while maintaining backward compatibility with flat keys |
| **New integration test: `test_long_term_credentials_rejected`** | Validates the session token gate end-to-end |
| **New unit test: `test_reload_rejects_long_term_retains_cached`** | Validates graceful degradation when long-term credentials are written during a reload |

Everything else — the FileBasedCredentialsProvider architecture (ArcSwapOption, mtime-based polling, background tokio task, graceful startup/degradation), the `discover_credentials_file()` helper, the `(Client, SdkConfig)` return from `validate_and_create_asm_client`, the `SMA_CREDENTIALS_RELOAD_SECS` / `SMA_DISABLE_IDENTITY_CACHE` debug flags, and all original integration tests — is unchanged from the reviewed and approved original.

### Security posture

- The file-based code path is **strictly more restrictive** than the existing default SDK credential chain, which already accepts static credentials via environment variables without validation
- IAM Roles Anywhere credentials always include a session token; legitimate use cases are unaffected by the gate
- On reload failure or gate rejection, previously cached valid credentials are retained (graceful degradation)

### Testing

- 93 unit tests pass (including 6 new credential provider tests)
- 34 integration tests pass (8 file-credential tests including session token gate + all existing SM tests)
- No regressions in secret retrieval, caching, security, role chaining, or prefetch