### PR TITLE
Make install script requirement for ACM capability more explicit in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ The Workload Credentials Provider exports certificates from AWS Certificate Mana
 
 The Certificate Management capability supports Linux and Windows, and works with web servers such as NGINX and Apache\.
 
-The Workload Credentials Provider uses the AWS credentials you provide in your environment to assume the role you have configured for each certificate, and then calls ACM to export the certificate\. The install script sets up the necessary permissions for the provider process to write certificate files to customer\-specified directories and execute refresh commands\.
+The Workload Credentials Provider uses the AWS credentials you provide in your environment to assume the role you have configured for each certificate, and then calls ACM to export the certificate\.
+
+**Important**  
+The Certificate Management capability requires elevated permissions for the provider to write certificate files and execute refresh commands\. The `install` script (Linux) or `install.ps1` script (Windows) configures these permissions automatically and is the recommended setup path\. On Linux, if you need to manage specific permissions yourself, use the `--no-privileges` or `--no-sudoers` flags rather than bypassing the install script entirely\. For details on what permissions are configured, see [Security considerations](#workload-credentials-provider-security)\.
 
 You can provide a custom configuration by passing `--config /path/to/config.toml` on startup or on reload while the provider is running\. On Windows, use `-Config C:\path\to\config.toml` when invoking the PowerShell scripts and `--Config C:\path\to\config.toml` when executing the binary command\. The reload re\-applies permissions and restarts the ACM service\.
 


### PR DESCRIPTION
## Description

### Why is this change being made?

1. README might not have made it clear enough that the install script is the recommended path for configuring ACM permissions.


### What is changing?

1. Replaced the brief mention of the install script in the Certificate Management capability section with an explicit Important callout.


### Related Links
- **Issue #, if available**: N/A

---

## Testing

### How was this tested?

1. local MD render

### When testing locally, provide testing artifact(s):

1. N/A

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [ ] Build and Unit tests are passing
  *If not, why:* N/A README update only
- [ ] Unit test coverage check is passing
  *If not, why:* N/A README update only
- [ ] Integration tests pass locally
  *If not, why:* N/A README update only
- [ ] I have updated integration tests (if needed)
  *If not, why:* N/A README update only
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [ ] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:* N/A README update only
- [x] I have updated README/documentation (if needed)
  *If not, why:*
- [ ] I have clearly called out breaking changes (if any)
  *If not, why:* N/A README update only

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
