### PR TITLE
Remove PrivateDevices=true from ACM service units

### DIFF
--- a/aws_workload_credentials_provider_common/configuration/aws-workload-credentials-provider-acm-nocaps.service
+++ b/aws_workload_credentials_provider_common/configuration/aws-workload-credentials-provider-acm-nocaps.service
@@ -18,7 +18,6 @@ ExecStart=/opt/aws/workload-credentials-provider/bin/aws-workload-credentials-pr
 ProtectSystem=full
 ProtectHome=true
 PrivateTmp=true
-PrivateDevices=true
 LimitCORE=0
 
 [Install]

--- a/aws_workload_credentials_provider_common/configuration/aws-workload-credentials-provider-acm.service
+++ b/aws_workload_credentials_provider_common/configuration/aws-workload-credentials-provider-acm.service
@@ -22,7 +22,6 @@ CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_SETUID CAP_SETGID CAP_AUDIT_WRITE
 ProtectSystem=full
 ProtectHome=true
 PrivateTmp=true
-PrivateDevices=true
 LimitCORE=0
 
 [Install]


### PR DESCRIPTION
## Description

### Why is this change being made?

PrivateDevices=true creates a minimal /dev namespace that prevents sudo from functioning correctly. Since systemd version 233 enabling this flag also enables `NoNewPrivileges` which prevent sudo from gaining root permission.   

Confirmed via systemd-run testing:
- PrivateDevices=true  → sudo exits with status 1
- PrivateDevices=false → sudo exits with status 0

Retains ProtectSystem=full, ProtectHome=true, and PrivateTmp=true for filesystem sandboxing.

### What is changing?

1. Removed `PrivateDevices=true` from `aws-workload-credentials-provider-acm.service` (caps variant)
2. Removed `PrivateDevices=true` from `aws-workload-credentials-provider-acm-nocaps.service` (no-caps variant)

### Related Links
- **Issue #, if available**: N/A — discovered during end-to-end Apache integration testing on Amazon Linux 2023

---

## Testing

### How was this tested?

1. Deployed EC2 instance (Amazon Linux 2023, c4.xlarge) with the ACM provider configured to export a certificate and run `refresh_command = "/usr/bin/systemctl restart httpd"`
2. With `PrivateDevices=true`: agent logs show `Refresh command exited with exit status: 1` — Apache never starts
3. After removing `PrivateDevices=true`: agent logs show `Refresh command succeeded` — Apache starts and serves the correct certificate
4. Verified via `openssl s_client` that served cert serial matches file cert serial
5. Isolated the root cause using `systemd-run --property=PrivateDevices=true --uid=aws-wcp --wait sudo -n /usr/bin/systemctl restart httpd` → exit 1; same command with `PrivateDevices=false` → exit 0

### When testing locally, provide testing artifact(s):

1. Agent log showing successful refresh after fix:
    
    INFO refresh_executor - Executing refresh command for arn:aws:acm:... INFO refresh_executor - Refresh command succeeded for arn:aws:acm:... INFO certificate_task - Certificate refresh successful for arn:aws:acm:...



3. Serial comparison: `File:0F436FE13D00A433EAE91259EE6DC76D` == `Served:0F436FE13D00A433EAE91259EE6DC76D` → PASS

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
- [x] I have filled out the Description and Testing sections above
- [x] Build and Unit tests are passing
- [x] Unit test coverage check is passing
- [x] Integration tests pass locally
- [ ] I have updated integration tests (if needed)
  *If not, why:* Existing integration tests don't exercise systemd sandbox properties; this is validated via E2E EC2 testing
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests
- [ ] I have updated README/documentation (if needed)
  *If not, why:* No user-facing documentation change needed — this is an internal service unit fix
- [x] I have clearly called out breaking changes (if any)

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.