### PR TITLE
Extract setup-permissions.sh from install script

### DIFF
--- a/aws_workload_credentials_provider_common/configuration/install
+++ b/aws_workload_credentials_provider_common/configuration/install
@@ -74,24 +74,17 @@ if [ ! -f "${PROVIDER_SOURCE_DIR}/${PROVIDER_BIN}" ]; then
 fi
 
 #
-# User and group setup
+# User, group, and directory permissions
 #
 
-groupadd -f "${PROVIDER_GROUP}"
-groupadd -f "${TOKEN_GROUP}"
-# useradd exits with code 9 if the user already exists — ignore that, but fail on any other error
-useradd -r -M -d "${PROVIDER_DIR}" -s /sbin/nologin -g "${PROVIDER_GROUP}" -G "${TOKEN_GROUP}" "${PROVIDER_USER}" || [ $? -eq 9 ]
+"${SCRIPT_DIR}/setup-permissions.sh"
 
 #
 # File installation
 #
 
-mkdir -p "${PROVIDER_DIR}"
-chmod 755 "${PROVIDER_DIR}"
-
 install -D -T -m 755 "${PROVIDER_SOURCE_DIR}/${PROVIDER_BIN}" "${PROVIDER_DIR}/bin/${PROVIDER_BIN}"
 install -D -T -m 755 "${TOKEN_SCRIPT}" "${PROVIDER_DIR}/bin/${TOKEN_SCRIPT}"
-chown "${PROVIDER_USER}" "${PROVIDER_DIR}"
 
 #
 # Service installation

--- a/aws_workload_credentials_provider_common/configuration/setup-permissions.sh
+++ b/aws_workload_credentials_provider_common/configuration/setup-permissions.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -e
+#
+# AWS Workload Credentials Provider - Permissions Setup
+# Sets up user, group, and directory permissions.
+#
+
+PATH=/bin:/usr/bin:/sbin:/usr/sbin
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+source "${SCRIPT_DIR}/common.sh"
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "This script must be run as root" >&2
+    exit 1
+fi
+
+#
+# User and group setup
+#
+
+groupadd -f "${PROVIDER_GROUP}"
+groupadd -f "${TOKEN_GROUP}"
+useradd -r -M -d "${PROVIDER_DIR}" -s /sbin/nologin -g "${PROVIDER_GROUP}" -G "${TOKEN_GROUP}" "${PROVIDER_USER}" || [ $? -eq 9 ]
+
+#
+# Directory permissions
+#
+
+mkdir -p "${PROVIDER_DIR}"
+chmod 755 "${PROVIDER_DIR}"
+chown "${PROVIDER_USER}" "${PROVIDER_DIR}"
+
+echo "Permissions setup complete."

--- a/aws_workload_credentials_provider_common/configuration/setup-permissions.sh
+++ b/aws_workload_credentials_provider_common/configuration/setup-permissions.sh
@@ -20,6 +20,7 @@ fi
 
 groupadd -f "${PROVIDER_GROUP}"
 groupadd -f "${TOKEN_GROUP}"
+# useradd exits with code 9 if the user already exists — ignore that, but fail on any other error
 useradd -r -M -d "${PROVIDER_DIR}" -s /sbin/nologin -g "${PROVIDER_GROUP}" -G "${TOKEN_GROUP}" "${PROVIDER_USER}" || [ $? -eq 9 ]
 
 #


### PR DESCRIPTION
Move user, group, and directory permission setup into a separate reusable script so it can be called independently by RPM post-install or other packaging workflows.

## Description

### Why is this change being made?

1. To reuse the code in RPM build


### What is changing?

1. Move user, group, and directory permission setup into a separate reusable script


### Related Links
- **Issue #, if available**:

---

## Testing
```
$ getent group awscreds
awscreds:x:1002:

$ getent group aws-wcp-token
aws-wcp-token:x:1003:aws-wcp

$ getent passwd aws-wcp
aws-wcp:x:992:1002::/opt/aws/workload-credentials-provider:/sbin/nologin

$ ls -ld /opt/aws/workload-credentials-provider
drwxr-xr-x. 4 aws-wcp root 29 Jun 20 18:17 /opt/aws/workload-credentials-provider
```


### How was this tested?

1. 
```
sudo ./install 
Permissions setup complete.
Installed aws-workload-credentials-provider-token.service
Installed aws-workload-credentials-provider-sm.service
Installed aws-workload-credentials-provider-acm.service (with CAP_DAC_OVERRIDE)
No ACM configuration found or ACM is disabled, skipping permissions setup
Created symlink /etc/systemd/system/multi-user.target.wants/aws-workload-credentials-provider-token.service → /etc/systemd/system/aws-workload-credentials-provider-token.service.
Created symlink /etc/systemd/system/multi-user.target.wants/aws-workload-credentials-provider-sm.service → /etc/systemd/system/aws-workload-credentials-provider-sm.service.
Created symlink /etc/systemd/system/multi-user.target.wants/aws-workload-credentials-provider-acm.service → /etc/systemd/system/aws-workload-credentials-provider-acm.service.
Started services
Installation complete.
$ curl http://localhost:2773/ping
healthy
```
### When testing locally, provide testing artifact(s):

1. See above

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [X ] I have reviewed, tested and understand all changes
  *If not, why:*
- [X ] I have filled out the Description and Testing sections above
  *If not, why:*
- [ X] Build and Unit tests are passing
  *If not, why:*
- [ X] Unit test coverage check is passing
  *If not, why:* 
- [ ] Integration tests pass locally
  *If not, why:*
- [ ] I have updated integration tests (if needed)
  *If not, why:* code refactor. no integ test change is required.
- [ X] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [ X] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [ ] I have updated README/documentation (if needed)
  *If not, why:* NA
- [ ] I have clearly called out breaking changes (if any)
  *If not, why:* NA

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
