### PR TITLE
fix: Restrict provider directory ownership to root

### DIFF
--- a/aws_workload_credentials_provider_common/configuration/setup-permissions.sh
+++ b/aws_workload_credentials_provider_common/configuration/setup-permissions.sh
@@ -29,6 +29,10 @@ useradd -r -M -d "${PROVIDER_DIR}" -s /sbin/nologin -g "${PROVIDER_GROUP}" -G "$
 
 mkdir -p "${PROVIDER_DIR}"
 chmod 755 "${PROVIDER_DIR}"
-chown "${PROVIDER_USER}" "${PROVIDER_DIR}"
+chown root:root "${PROVIDER_DIR}"
+
+# Grant aws-wcp write access only to logs directory
+mkdir -p "${PROVIDER_DIR}/logs"
+chown "${PROVIDER_USER}:${PROVIDER_GROUP}" "${PROVIDER_DIR}/logs"
 
 echo "Permissions setup complete."

--- a/aws_workload_credentials_provider_common/configuration/setup-permissions.sh
+++ b/aws_workload_credentials_provider_common/configuration/setup-permissions.sh
@@ -34,5 +34,6 @@ chown root:root "${PROVIDER_DIR}"
 # Grant aws-wcp write access only to logs directory
 mkdir -p "${PROVIDER_DIR}/logs"
 chown "${PROVIDER_USER}:${PROVIDER_GROUP}" "${PROVIDER_DIR}/logs"
+chmod 750 "${PROVIDER_DIR}/logs"
 
 echo "Permissions setup complete."


### PR DESCRIPTION
## Description

### Why is this change being made?

1. The installer grants the service account (`aws-wcp`) ownership of the provider directory (`/opt/aws/workload-credentials-provider`), but the service account only needs write access to the `logs/` subdirectory.
2. Tightening directory ownership to root ensures the service account only has write access where it is needed.


### What is changing?

1. `setup-permissions.sh`: Changed `PROVIDER_DIR` ownership from `aws-wcp` to `root:root`.
2. `setup-permissions.sh`: Pre-create `logs/` subdirectory owned by `aws-wcp:awscreds` i.e. the only location the provider needs to write to at runtime.


### Related Links
- **Issue #, if available**: N/A

---

## Testing

### How was this tested?

Tested manually on AL2023 EC2 linux

1. Fresh install on EC2 (AL2023) — verified correct directory ownership (`PROVIDER_DIR` = root:root, `logs/` = aws-wcp:awscreds, `bin/` = root:root)
2. Secrets Manager capability — retrieved a secret via localhost HTTP endpoint
3. ACM capability — certificate exported to disk, refresh command (`nginx -s reload`) succeeded via sudo
4. Logging — both `acm_provider.log` and `secrets_manager_provider.log` created and written in `logs/`
5. Crash recovery — killed SM and ACM processes with `kill -9`, verified systemd auto-restarted both with new PIDs and logs continued writing
6. Token service restart — confirmed new SSRF token generated
7. Re-install idempotency — ran install twice, permissions and services remain correct
8. Uninstall/reinstall cycle — clean uninstall followed by fresh install works
9. ACM reload — `acm reload --config` command works

### When testing locally, provide testing artifact(s):

1. `ls -ld /opt/aws/workload-credentials-provider` → `drwxr-xr-x. 4 root root`
2. `ls -ld /opt/aws/workload-credentials-provider/logs` → `drwxr-xr-x. 2 aws-wcp awscreds`
3. `ls -ld /opt/aws/workload-credentials-provider/bin` → `drwxr-xr-x. 2 root root`

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [x] Build and Unit tests are passing
  *If not, why:*
- [ ] Unit test coverage check is passing
  *If not, why: No Rust code changed — shell script only*
- [ ] Integration tests pass locally
  *If not, why: Change is to a shell script; manually validated all capabilities on EC2*
- [ ] I have updated integration tests (if needed)
  *If not, why: N/A manual verification performed*
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [ ] I have updated README/documentation (if needed)
  *If not, why: N/A*
- [ ] I have clearly called out breaking changes (if any)
  *If not, why: N/A*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
