### PR TITLE
fix: prevent acm reload from truncating config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,6 +754,7 @@ dependencies = [
  "log4rs",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio-util",
 ]
 

--- a/aws_workload_credentials_provider/Cargo.toml
+++ b/aws_workload_credentials_provider/Cargo.toml
@@ -29,3 +29,6 @@ serde_json = "1"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[target.'cfg(unix)'.dev-dependencies]
+tempfile = "3"
+

--- a/aws_workload_credentials_provider/src/main.rs
+++ b/aws_workload_credentials_provider/src/main.rs
@@ -146,7 +146,17 @@ fn acm_reload(
         // Validate before overwriting the live config
         ConfigValidator::new().validate(Some(config.as_str()))?;
 
-        std::fs::copy(config, DEFAULT_CONFIG_PATH)?;
+        // Skip the copy when the provided config already resolves to the default
+        // path. `std::fs::copy` opens the destination with truncate, so a same-file
+        // copy would empty the live config before it's read back, wiping it out
+        // (unlike `cp`, which guards against copying a file onto itself).
+        // Permissions are still (re-)applied below and the reload continues.
+        if should_copy_config(
+            std::path::Path::new(config),
+            std::path::Path::new(DEFAULT_CONFIG_PATH),
+        )? {
+            std::fs::copy(config, DEFAULT_CONFIG_PATH)?;
+        }
         std::fs::set_permissions(DEFAULT_CONFIG_PATH, std::fs::Permissions::from_mode(0o440))?;
 
         let status = std::process::Command::new("chown")
@@ -205,6 +215,21 @@ fn acm_reload(config_path: Option<String>) -> Result<(), Box<dyn std::error::Err
     }
 
     Ok(())
+}
+
+/// Returns whether `src` should be copied to `dst`, i.e. they are not the same
+/// file on disk.
+///
+/// Both paths are canonicalized so symlinks and relative segments are resolved.
+/// `src` must exist (it is validated before this is called); failing to
+/// canonicalize it surfaces a clear error rather than falling through to a
+/// confusing copy failure. `dst` may not exist yet (first-time reload), in
+/// which case it cannot be the same file, so the copy should proceed.
+#[cfg(unix)]
+fn should_copy_config(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<bool> {
+    let src_canonical = std::fs::canonicalize(src)?;
+    let dst_canonical = std::fs::canonicalize(dst).ok();
+    Ok(dst_canonical.as_ref() != Some(&src_canonical))
 }
 
 #[cfg(unix)]
@@ -313,6 +338,79 @@ fn generate_installer_json(validated: &ValidatedConfig) -> String {
         certificates,
     })
     .unwrap()
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::should_copy_config;
+    use std::os::unix::fs::symlink;
+    use tempfile::TempDir;
+
+    #[test]
+    fn skips_copy_for_identical_path() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "a = 1").unwrap();
+
+        assert!(!should_copy_config(&path, &path).unwrap());
+    }
+
+    #[test]
+    fn skips_copy_for_relative_and_absolute_forms() {
+        let dir = TempDir::new().unwrap();
+        let abs = dir.path().join("config.toml");
+        std::fs::write(&abs, "a = 1").unwrap();
+        // A path with a redundant "." segment resolves to the same file.
+        let dotted = dir.path().join(".").join("config.toml");
+
+        assert!(!should_copy_config(&abs, &dotted).unwrap());
+    }
+
+    #[test]
+    fn skips_copy_for_symlink_to_target() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("config.toml");
+        std::fs::write(&target, "a = 1").unwrap();
+        let link = dir.path().join("config-link.toml");
+        symlink(&target, &link).unwrap();
+
+        assert!(!should_copy_config(&link, &target).unwrap());
+    }
+
+    #[test]
+    fn copies_for_distinct_files() {
+        let dir = TempDir::new().unwrap();
+        let a = dir.path().join("a.toml");
+        let b = dir.path().join("b.toml");
+        std::fs::write(&a, "a = 1").unwrap();
+        std::fs::write(&b, "b = 2").unwrap();
+
+        assert!(should_copy_config(&a, &b).unwrap());
+    }
+
+    #[test]
+    fn copies_when_destination_missing() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("config.toml");
+        std::fs::write(&src, "a = 1").unwrap();
+        let missing = dir.path().join("does-not-exist.toml");
+
+        // A missing destination cannot be the same file, so the copy proceeds
+        // (e.g. a first-time reload that creates the default config).
+        assert!(should_copy_config(&src, &missing).unwrap());
+    }
+
+    #[test]
+    fn errors_when_source_missing() {
+        let dir = TempDir::new().unwrap();
+        let missing = dir.path().join("does-not-exist.toml");
+        let dst = dir.path().join("config.toml");
+        std::fs::write(&dst, "a = 1").unwrap();
+
+        // The source is validated before this is called, so an unresolvable
+        // source surfaces a clear error instead of a confusing copy failure.
+        assert!(should_copy_config(&missing, &dst).is_err());
+    }
 }
 
 /// Resolves the config file path: uses the given path if provided,


### PR DESCRIPTION
## Description

### Why is this change being made?

1. `acm reload --config /etc/aws-workload-credentials-provider/config.toml` (pointing `--config` at the default config path) silently truncates `config.toml` to 0 bytes and takes down the ACM service. This is because `std::fs::copy(src, dst)` opens the destination with `O_TRUNC` before reading the source — when they're the same file, the content is destroyed before the read even starts.


### What is changing?

1. `acm_reload` in `aws_workload_credentials_provider/src/main.rs` now compares the canonical source path against the canonical `DEFAULT_CONFIG_PATH` and skips the copy when they resolve to the same file. Permissions, ownership, sudoers regeneration, `daemon-reload`, and service restart still run as before.
2. Added unit tests for the same-file detection logic (extracted as a `should_copy_config` helper) covering: same path, missing destination, different paths, and symlink-pointing-to-destination.


### Related Links
- **Issue #, if available**: [#237](https://github.com/aws/aws-workload-credentials-provider/issues/237)

---

## Testing

### How was this tested?

1. Reproduced the bug on a Linux dev desk (Amazon Linux 2) with the pre-fix binary:
     - Installed provider via `./install`, then ran `sudo aws-workload-credentials-provider acm reload --config /etc/aws-workload-credentials-provider/config.toml`
     - Confirmed `/etc/aws-workload-credentials-provider/config.toml` was truncated from 591 bytes to 0 bytes
  2. Applied the fix, rebuilt the binary, ran the same reproduction — config remained intact and the reload proceeded through permissions/systemd-reload/restart steps.
  4. Ran full workspace unit tests: `cargo test --all-features --workspace --exclude integration-tests`.
  5. Ran integration tests (excluding pre-existing failures unrelated to this change): `cargo test -- --test-threads=1`.
  6.  no new warnings `cargo clippy --all-targets --all-features`

### When testing locally, provide testing artifact(s):

1. Before fix:

     $ sudo wc -c /etc/aws-workload-credentials-provider/config.toml
     591 /etc/aws-workload-credentials-provider/config.toml
     $ sudo ./target/release/aws-workload-credentials-provider acm reload
         --config /etc/aws-workload-credentials-provider/config.toml
     $ sudo wc -c /etc/aws-workload-credentials-provider/config.toml
     0 /etc/aws-workload-credentials-provider/config.toml

  2. After fix:

     $ sudo wc -c /etc/aws-workload-credentials-provider/config.toml
     591 /etc/aws-workload-credentials-provider/config.toml
     $ sudo ./target/debug/aws-workload-credentials-provider acm reload
         --config /etc/aws-workload-credentials-provider/config.toml
     $ sudo wc -c /etc/aws-workload-credentials-provider/config.toml
     591 /etc/aws-workload-credentials-provider/config.toml

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [x] Build and Unit tests are passing
  *If not, why:*
- [x] Unit test coverage check is passing
  *If not, why:* *Coverage on the new `should_copy_config` helper is 100% (4 test cases); overall `main.rs` coverage went from 0% to 29% since this file previously had no unit tests.*
- [x] Integration tests pass locally
  *If not, why:*
- [ ] I have updated integration tests (if needed)
  *If not, why:* N/A
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [ ] I have updated README/documentation (if needed)
  *If not, why:* N/A
- [ ] I have clearly called out breaking changes (if any)
  *If not, why:* N/A

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
