### PR TITLE
Separate the Windows and Linux binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,19 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Validate required secrets
+        env:
+          RELEASE_BUCKET: ${{ secrets.RELEASE_BUCKET }}
+          RELEASE_WINDOWS_BUCKET: ${{ secrets.RELEASE_WINDOWS_BUCKET }}
+          RELEASE_WINDOWS_BIN_PATH: ${{ secrets.RELEASE_WINDOWS_BIN_PATH }}
+        run: |
+          for var in RELEASE_BUCKET RELEASE_WINDOWS_BUCKET RELEASE_WINDOWS_BIN_PATH; do
+            if [[ -z "${!var}" ]]; then
+              echo "::error::Required secret $var is empty or unset"
+              exit 1
+            fi
+          done
+
       - name: Download binary artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -59,8 +72,8 @@ jobs:
       - name: Upload artifacts to S3
         env:
           RELEASE_BUCKET: ${{ secrets.RELEASE_BUCKET }}
-          WINDOWS_RELEASE_BUCKET: ${{ secrets.WINDOWS_RELEASE_BUCKET }}
-          WINDOWS_BIN_PATH: ${{ secrets.RELEASE_WINDOWS_BIN_PATH }}
+          RELEASE_WINDOWS_BUCKET: ${{ secrets.RELEASE_WINDOWS_BUCKET }}
+          RELEASE_WINDOWS_BIN_PATH: ${{ secrets.RELEASE_WINDOWS_BIN_PATH }}
         run: |
           # Each downloaded artifact is a directory named "aws-wcp-<target>"
           # (e.g. artifacts/aws-wcp-x86_64-unknown-linux-gnu/) containing a
@@ -78,8 +91,8 @@ jobs:
 
             # Windows targets go to a separate bucket under a key prefix
             if [[ "$target" == *windows* ]]; then
-              bucket="$WINDOWS_RELEASE_BUCKET"
-              key_prefix="${WINDOWS_BIN_PATH}/"
+              bucket="$RELEASE_WINDOWS_BUCKET"
+              key_prefix="${RELEASE_WINDOWS_BIN_PATH}/"
             else
               bucket="$RELEASE_BUCKET"
               key_prefix=""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,10 @@ jobs:
           aws-region: us-west-2
 
       - name: Upload artifacts to S3
+        env:
+          RELEASE_BUCKET: ${{ secrets.RELEASE_BUCKET }}
+          WINDOWS_RELEASE_BUCKET: ${{ secrets.WINDOWS_RELEASE_BUCKET }}
+          WINDOWS_BIN_PATH: ${{ secrets.RELEASE_WINDOWS_BIN_PATH }}
         run: |
           # Each downloaded artifact is a directory named "aws-wcp-<target>"
           # (e.g. artifacts/aws-wcp-x86_64-unknown-linux-gnu/) containing a
@@ -71,9 +75,19 @@ jobs:
               exit 1
             fi
             binary=$(find "$dir" -type f -name 'aws-workload-credentials-provider*')
+
+            # Windows targets go to a separate bucket under a key prefix
+            if [[ "$target" == *windows* ]]; then
+              bucket="$WINDOWS_RELEASE_BUCKET"
+              key_prefix="${WINDOWS_BIN_PATH}/"
+            else
+              bucket="$RELEASE_BUCKET"
+              key_prefix=""
+            fi
+
             aws s3api put-object \
-              --bucket "${{ secrets.RELEASE_BUCKET }}" \
-              --key "${{ inputs.version }}/${target}/$(basename "$binary")" \
+              --bucket "$bucket" \
+              --key "${key_prefix}${{ inputs.version }}/${target}/$(basename "$binary")" \
               --body "$binary" \
               --if-none-match "*"
           done

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -20,8 +20,24 @@ jobs:
   integ:
     uses: ./.github/workflows/integration-tests.yml
     secrets: inherit
+  validate-secrets:
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - name: Validate required secrets
+        env:
+          STAGING_BUCKET: ${{ secrets.STAGING_BUCKET }}
+          STAGING_WINDOWS_BUCKET: ${{ secrets.STAGING_WINDOWS_BUCKET }}
+          STAGING_WINDOWS_BIN_PATH: ${{ secrets.STAGING_WINDOWS_BIN_PATH }}
+        run: |
+          for var in STAGING_BUCKET STAGING_WINDOWS_BUCKET STAGING_WINDOWS_BIN_PATH; do
+            if [[ -z "${!var}" ]]; then
+              echo "::error::Required secret $var is empty or unset"
+              exit 1
+            fi
+          done
   publish:
-    needs: [integ]
+    needs: [integ, validate-secrets]
     environment: staging
     strategy:
       fail-fast: false
@@ -68,7 +84,7 @@ jobs:
 
       - name: Upload artifacts to S3
         env:
-          BUCKET: ${{ runner.os == 'Windows' && secrets.WINDOWS_STAGING_BUCKET || secrets.STAGING_BUCKET }}
+          BUCKET: ${{ runner.os == 'Windows' && secrets.STAGING_WINDOWS_BUCKET || secrets.STAGING_BUCKET }}
           KEY_PREFIX: ${{ runner.os == 'Windows' && format('{0}/', secrets.STAGING_WINDOWS_BIN_PATH) || '' }}
           BIN: aws-workload-credentials-provider${{ matrix.ext }}
         shell: bash

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -29,10 +29,13 @@ jobs:
         include:
           - runner: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+            ext: ""
           - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
+            ext: ""
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
+            ext: ".exe"
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Harden Runner
@@ -52,7 +55,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: aws-wcp-${{ matrix.target }}
-          path: target/${{ matrix.target }}/release/aws-workload-credentials-provider${{ runner.os == 'Windows' && '.exe' || '' }}
+          path: target/${{ matrix.target }}/release/aws-workload-credentials-provider${{ matrix.ext }}
           if-no-files-found: error
           retention-days: 1
 
@@ -64,5 +67,10 @@ jobs:
           aws-region: us-west-2
 
       - name: Upload artifacts to S3
+        env:
+          BUCKET: ${{ runner.os == 'Windows' && secrets.WINDOWS_STAGING_BUCKET || secrets.STAGING_BUCKET }}
+          KEY_PREFIX: ${{ runner.os == 'Windows' && format('{0}/', secrets.STAGING_WINDOWS_BIN_PATH) || '' }}
+          BIN: aws-workload-credentials-provider${{ matrix.ext }}
+        shell: bash
         run: |
-          aws s3 cp target/${{ matrix.target }}/release/aws-workload-credentials-provider${{ runner.os == 'Windows' && '.exe' || '' }} "s3://${{ secrets.STAGING_BUCKET }}/${{ github.run_id }}/${{ matrix.target }}/aws-workload-credentials-provider${{ runner.os == 'Windows' && '.exe' || '' }}"
+          aws s3 cp "target/${{ matrix.target }}/release/$BIN" "s3://$BUCKET/$KEY_PREFIX${{ github.run_id }}/${{ matrix.target }}/$BIN"


### PR DESCRIPTION
## Description

### Why is this change being made?

1. Separate the Windows and linux binaries into separate paths and buckets for signing.


### What is changing?

1. Simple if/else statements to populate the S3 bucket name and the object path from GH secrets.


### Related Links
- **Issue #, if available**:

---

## Testing

### How was this tested?

1. 

### When testing locally, provide testing artifact(s):

1. 

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [x] Build and Unit tests are passing
  *If not, why:*
- [x] Unit test coverage check is passing
  *If not, why:*
- [x] Integration tests pass locally
  *If not, why:*
- [ ] I have updated integration tests (if needed)
  *If not, why:*
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [ ] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [ ] I have updated README/documentation (if needed)
  *If not, why:*
- [ ] I have clearly called out breaking changes (if any)
  *If not, why:*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
