### PR TITLE
Add RPM packaging checks to CR

### DIFF
--- a/.crux_template.md
+++ b/.crux_template.md
@@ -81,6 +81,9 @@
 - [ ] I have run `cargo fmt --check` and `cargo clippy` with no warnings
 
   *If not, why:*
+- [ ] I have called out any changes to installation, service, or configuration files under `aws_workload_credentials_provider_common/configuration/`
+
+  *If not, why:*
 
 ---
 
@@ -91,3 +94,4 @@
 - Reviewee checklist has been accurately filled out
 - Code changes align with stated purpose in description
 - Test coverage adequately validates the changes
+- Changes under `aws_workload_credentials_provider_common/configuration/` are RPM-compatible


### PR DESCRIPTION
The AL2023 RPM spec consumes files from
aws_workload_credentials_provider_common/configuration/ directly, so changes there can break packaging without any signal in the code review.

Add an author checklist item to call out such changes and confirm the spec is updated to match, and a reviewer checklist item to verify install paths, file ownership/permissions, users/groups, and systemd unit locations still match what the spec installs.

## Description

### Why is this change being made?

1.


### What is changing?

1.


### Related Links
- **Issue #, if available**:

---

## Testing

### How was this tested?

1. 

### When testing locally, provide testing artifact(s):

1. 

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [ ] I have reviewed, tested and understand all changes
  *If not, why:*
- [ ] I have filled out the Description and Testing sections above
  *If not, why:*
- [ ] Build and Unit tests are passing
  *If not, why:*
- [ ] Unit test coverage check is passing
  *If not, why:*
- [ ] Integration tests pass locally
  *If not, why:*
- [ ] I have updated integration tests (if needed)
  *If not, why:*
- [ ] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [ ] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [ ] I have updated README/documentation (if needed)
  *If not, why:*
- [ ] I have clearly called out breaking changes (if any)
  *If not, why:*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
